### PR TITLE
Remove postinstall hook for serenity-bdd update from examples

### DIFF
--- a/src/docs/handbook/getting-started/serenity-js-with-playwright-test.mdx
+++ b/src/docs/handbook/getting-started/serenity-js-with-playwright-test.mdx
@@ -179,20 +179,17 @@ View [live Serenity BDD report on GitHub](https://serenity-js.github.io/serenity
 />
 
 To produce Serenity BDD reports, your test suite must:
-- download the Serenity BDD CLI, by calling `serenity-bdd update` (which caches the CLI `jar` locally)
 - produce intermediate Serenity BDD `.json` reports, by registering [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter/) as per the [configuration instructions](#configuring-serenityjs)
 - invoke the Serenity BDD CLI when you want to produce the report, by calling `serenity-bdd run`
 
 The pattern used by all the [Serenity/JS Project Templates](/handbook/getting-started/project-templates/) relies
 on using:
-- a [`postinstall`](https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-operation-order) NPM script to download the Serenity BDD CLI
 - [`npm-failsafe`](https://www.npmjs.com/package/npm-failsafe) to run the reporting process even if the test suite itself has failed (which is precisely when you need test reports the most...).
 - [`rimraf`](https://www.npmjs.com/package/rimraf) as a convenience method to remove any test reports left over from the previous run
 
 ```json title="package.json"
 {
   "scripts": {
-    "postinstall": "serenity-bdd update",
     "clean": "rimraf target",
     "test": "failsafe clean test:execute test:report",
     "test:execute": "playwright test",

--- a/src/docs/handbook/getting-started/serenity-js-with-protractor.mdx
+++ b/src/docs/handbook/getting-started/serenity-js-with-protractor.mdx
@@ -227,20 +227,17 @@ and complete [`protractor.conf.js`](https://github.com/serenity-js/serenity-js-m
 a Java program downloaded and managed by the [`@serenity-js/serenity-bdd`](/api/serenity-bdd/) module.
 
 To produce Serenity BDD reports, your test suite must:
-- download the Serenity BDD CLI, by calling `serenity-bdd update` which caches the CLI `jar` locally
 - produce intermediate Serenity BDD `.json` reports, by registering [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter/) as per the [configuration instructions](#configuring-serenityjs-and-protractor)
 - invoke the Serenity BDD CLI when you want to produce the report, by calling `serenity-bdd run`
 
 The pattern used by all the [Serenity/JS Project Templates](/handbook/getting-started/project-templates/) relies
 on using:
-- a [`postinstall`](https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-operation-order) NPM script to download the Serenity BDD CLI
 - [`npm-failsafe`](https://www.npmjs.com/package/npm-failsafe) to run the reporting process even if the test suite itself has failed (which is precisely when you need test reports the most...).
 - [`rimraf`](https://www.npmjs.com/package/rimraf) as a convenience method to remove any test reports left over from the previous run
 
 ```json title="package.json"
 {
   "scripts": {
-    "postinstall": "serenity-bdd update",
     "clean": "rimraf target",
     "test": "failsafe clean test:execute test:report",
     "test:execute": "protractor ./protractor.conf.js",
@@ -582,7 +579,6 @@ Update the `script` section in your `package.json` to use `wdio` instead of `pro
 ```diff title="package.json"
 {
   "scripts": {
-    "postinstall": "serenity-bdd update",
     "clean": "rimraf target",
     "test": "failsafe clean test:execute test:report",
 -   "test:execute": "protractor ./protractor.conf.js",

--- a/src/docs/handbook/getting-started/serenity-js-with-webdriverio.mdx
+++ b/src/docs/handbook/getting-started/serenity-js-with-webdriverio.mdx
@@ -175,20 +175,17 @@ Learn more about:
 a Java program downloaded and managed by the [`@serenity-js/serenity-bdd`](/api/serenity-bdd/) module.
 
 To produce Serenity BDD reports, your test suite must:
-- download the Serenity BDD CLI, by calling `serenity-bdd update` which caches the CLI `jar` locally
 - produce intermediate Serenity BDD `.json` reports, by registering [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter/) as per the [configuration instructions](#configuring-serenityjs-and-webdriverio)
 - invoke the Serenity BDD CLI when you want to produce the report, by calling `serenity-bdd run`
 
 The pattern used by all the [Serenity/JS Project Templates](/handbook/getting-started/project-templates/) relies
 on using:
-- a [`postinstall`](https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-operation-order) NPM script to download the Serenity BDD CLI
 - [`npm-failsafe`](https://www.npmjs.com/package/npm-failsafe) to run the reporting process even if the test suite itself has failed (which is precisely when you need test reports the most...).
 - [`rimraf`](https://www.npmjs.com/package/rimraf) as a convenience method to remove any test reports left over from the previous run
 
 ```json title="package.json"
 {
   "scripts": {
-    "postinstall": "serenity-bdd update",
     "clean": "rimraf target",
     "test": "failsafe clean test:execute test:report",
     "test:execute": "wdio wdio.conf.ts",

--- a/src/docs/handbook/reporting/serenity-bdd-reporter.mdx
+++ b/src/docs/handbook/reporting/serenity-bdd-reporter.mdx
@@ -462,20 +462,17 @@ npx serenity-bdd --help
 ```
 
 To produce Serenity BDD reports, your test suite must:
-- call `serenity-bdd update`, typically as part of the `postinstall` or `pretest` [NPM script](https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-operation-order)
 - use the [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter), which produces intermediate Serenity BDD `.json` reports
 - call `serenity-bdd run` when the test run completes to generate the aggregated HTML report
 
 The pattern used by all the [Serenity/JS Project Templates](/handbook/getting-started/project-templates/) relies
 on using:
-- a [`postinstall`](https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-operation-order) NPM script to download the Serenity BDD CLI
 - [`npm-failsafe`](https://www.npmjs.com/package/npm-failsafe) to run the reporting process even if the test suite itself has failed (which is precisely when you need test reports the most...).
 - [`rimraf`](https://www.npmjs.com/package/rimraf) as a convenience method to remove any test reports left over from the previous run
 
 ```json title="package.json"
 {
   "scripts": {
-    "postinstall": "serenity-bdd update",
     "clean": "rimraf target",
     "test": "failsafe clean test:execute test:report",
     "test:execute": "cucumber-js",


### PR DESCRIPTION
This action is no longer needed after serenity-js/serenity-js#2591.

I've removed all related steps from examples, but left the section that describes `update` command. I think this section might need some additional docs or examples of cases when the `update` command might be useful.