### PR TITLE
Fix Selector Alias Example

### DIFF
--- a/src/docs/handbook/web-testing/page-element-query-language.md
+++ b/src/docs/handbook/web-testing/page-element-query-language.md
@@ -129,8 +129,8 @@ selector value using an [`Answerable<string>`](/api/core#Answerable):
 import { Answerable, q } from '@serenity-js/core'
 import { By, PageElement } from '@serenity-js/web'
 
-const byTestId = (dataTestId: Answerable<string>) =>
-    PageElement.located(By.css(q`[data-test-id="${ dataTestId }"]`))
+export const byTestId = (dataTestId: Answerable<string>) =>
+    By.css(q`[data-test-id="${ dataTestId }"]`)
 ```
 
 Note that the example above uses [tag function `q`](/api/core/function/q) to concatenate a static string with an [`Answerable<string>`](/api/core/#Answerable).


### PR DESCRIPTION
I noticed while trying to use this example that it wasn't quite right.

I'm relatively certain that this example wasn't intended to have the `PageElement.located(` on it.

Now, it matches the `byRole` example above it. I've tried it and now it works just fine.