### PR TITLE
docs: add note about hard-coded credentials in getting started guides

### DIFF
--- a/src/docs/getting-started/cucumber.mdx
+++ b/src/docs/getting-started/cucumber.mdx
@@ -262,6 +262,10 @@ A self-contained project you can copy in full. It includes:
 
 Run `npm install` then `npm test` — the Serenity BDD HTML report lands in `reports/serenity/index.html`.
 
+:::note Credentials in examples
+The password `secret_sauce` is hard-coded in these examples to keep them simple and self-contained. In real-world tests, load credentials from environment variables or a password vault to avoid committing secrets to your repository.
+:::
+
 <Tabs>
 <TabItem value="feature" label="swag-labs.feature" default>
 

--- a/src/docs/getting-started/index.mdx
+++ b/src/docs/getting-started/index.mdx
@@ -99,6 +99,10 @@ The following scenario is implemented at four levels of Serenity/JS adoption —
 It's a fictive online store where you can browse products, add items to a cart, and complete checkout flows.
 :::
 
+:::note Credentials in examples
+The password `secret_sauce` is hard-coded in these examples to keep them simple and self-contained. In real-world tests, load credentials from environment variables or a password vault to avoid committing secrets to your repository.
+:::
+
 ### Level 0: Vanilla Playwright
 
 This is the starting point most teams are familiar with — no Serenity/JS, all logic in one flat script.

--- a/src/docs/getting-started/playwright.mdx
+++ b/src/docs/getting-started/playwright.mdx
@@ -220,6 +220,10 @@ A self-contained project you can copy in full. It includes:
 
 Run `npm install` then `npm test` — the Serenity BDD HTML report lands in `reports/serenity/index.html`.
 
+:::note Credentials in examples
+The password `secret_sauce` is hard-coded in these examples to keep them simple and self-contained. In real-world tests, load credentials from environment variables or a password vault to avoid committing secrets to your repository.
+:::
+
 <Tabs>
 <TabItem value="package" label="package.json" default>
 

--- a/src/docs/getting-started/webdriverio.mdx
+++ b/src/docs/getting-started/webdriverio.mdx
@@ -208,6 +208,10 @@ A self-contained project you can copy in full. It includes:
 
 Run `npm install` then `npm run serenity` — the Serenity BDD HTML report lands in `target/site/serenity/index.html`.
 
+:::note Credentials in examples
+The password `secret_sauce` is hard-coded in these examples to keep them simple and self-contained. In real-world tests, load credentials from environment variables or a password vault to avoid committing secrets to your repository.
+:::
+
 <Tabs>
 <TabItem value="package" label="package.json" default>
 


### PR DESCRIPTION
Add an admonition to each getting started guide (index, playwright, webdriverio, cucumber) noting that the password is hard-coded to simplify the examples and that real-world tests should use environment variables or a password vault.