### PR TITLE
docs: cross-link community tutorials from getting-started pages

### DIFF
--- a/src/docs/getting-started/cucumber.mdx
+++ b/src/docs/getting-started/cucumber.mdx
@@ -502,6 +502,11 @@ Check the [Troubleshooting guide](/handbook/troubleshooting/) for solutions to c
 - **[Project templates](/getting-started/project-templates/)** — all available starter projects
 - **[Troubleshooting](/handbook/troubleshooting/)** — solutions to common issues
 
+### Community tutorials
+
+- **[Reuse Component Test Code with BDD Scenarios using Serenity/JS and Playwright](https://www.pilot-period.org/sjs-playwright-ct-cucumber)** — reuse the same Screenplay Tasks across component tests and Cucumber scenarios, by Jan Graefe
+- **[Serenity/JS and Actor Notepads for Injecting User Credentials](https://www.pilot-period.org/sjs-actors-notepad)** — manage per-actor test credentials using the Notepad pattern, by Jan Graefe
+
 :::note Using Playwright Test instead of Cucumber?
 If you don't need Gherkin syntax, Serenity/JS works directly with Playwright Test or WebdriverIO for a simpler setup. See [Serenity/JS with Playwright](/getting-started/playwright/) or [Serenity/JS with WebdriverIO](/getting-started/webdriverio/).
 :::

--- a/src/docs/getting-started/index.mdx
+++ b/src/docs/getting-started/index.mdx
@@ -449,3 +449,8 @@ All levels coexist in the same project — you're in control of how far and how 
 - **[For Cucumber users](/getting-started/cucumber/)** — add reporting and Screenplay to your Gherkin scenarios
 - **[15-minute tutorial](/handbook/tutorials/your-first-web-scenario/)** — build your first Screenplay test
 - **[Project Templates](/getting-started/project-templates/)** — pre-configured starter projects
+
+### What others are saying
+
+- **[Open Letter to Jan Molak](https://www.pilot-period.org/serenity-js-open-letter/)** — "Its value is that it encourages teams to think about behaviour, intent, and outcomes," by Jan Graefe
+- **[Code was never the hard part](/blog/code-was-never-the-hard-part/)** — on why design thinking matters more than code generation

--- a/src/docs/getting-started/playwright.mdx
+++ b/src/docs/getting-started/playwright.mdx
@@ -485,6 +485,11 @@ Check the [Troubleshooting guide](/handbook/troubleshooting/) for solutions to c
 - **[Project templates](/getting-started/project-templates/)** — all available starter projects
 - **[Troubleshooting](/handbook/troubleshooting/)** — solutions to common issues
 
+### Community tutorials
+
+- **[Serenity/JS and Actor Notepads for Injecting User Credentials](https://www.pilot-period.org/sjs-actors-notepad)** — a cleaner approach to managing test credentials using actor-specific data, by Jan Graefe
+- **[Reuse Component Test Code with BDD Scenarios](https://www.pilot-period.org/sjs-playwright-ct-cucumber)** — reuse Screenplay Tasks across component tests and Cucumber scenarios, by Jan Graefe
+
 :::note Using WebdriverIO instead?
 Serenity/JS works just as well with WebdriverIO. The Task code is identical — only the config differs. See [Serenity/JS with WebdriverIO](/getting-started/webdriverio/).
 :::


### PR DESCRIPTION
Add 'Community tutorials' sections to the Playwright and Cucumber getting-started pages, linking to Jan Graefe's pilot-period.org articles on Actor Notepads and BDD scenario reuse.

Add 'What others are saying' section to the Why Serenity/JS page, linking to Graefe's open letter and the 'Code was never the hard part' response post.

URLs verified against src/docs/community/resources.mdx and src/blog/2026-06-05-code-was-never-the-hard-part/index.mdx.