### PR TITLE
chore: replace Tidelift with GitHub Security Advisories

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,4 +1,3 @@
 # These are supported funding model platforms
 
 github: [ serenity-js, jan-molak ]
-tidelift: "npm/@serenity-js/core"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,10 @@
- ## Security contact information
+# Security Policy
 
-To report a security vulnerability, please use the
-[Tidelift security contact](https://tidelift.com/security).
-Tidelift will coordinate the fix and disclosure.
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Serenity/JS, please report it through
+[GitHub Security Advisories](https://github.com/serenity-js/serenity-js/security/advisories/new).
+
+This allows us to discuss and fix the issue privately before any public disclosure.
+
+Please do **not** open a public GitHub issue for security vulnerabilities.


### PR DESCRIPTION
- Update SECURITY.md to point to GitHub's private vulnerability reporting instead of Tidelift
- Remove tidelift from .github/funding.yml