### PR TITLE
docs(community): add missing Graefe articles to resources page

### DIFF
--- a/src/docs/community/resources.mdx
+++ b/src/docs/community/resources.mdx
@@ -9,9 +9,17 @@ If you've written an article, tutorial, or a blog post, recorded a video, or are
 please [add it to the list below](https://github.com/serenity-js/serenity-js/tree/main/documentation/serenity-js.org/community/resources.mdx) to share the news with the community!
 
 ## Articles
+- **["Open Letter to Jan Molak"](https://www.pilot-period.org/serenity-js-open-letter)**
+by [Jan Graefe](https://www.linkedin.com/in/jan-graefe-5b515b260/)
+(2026-06-04)
+
 - **["Serenity/JS and Actor Notepads for Injecting User Credentials"](https://www.pilot-period.org/sjs-actors-notepad)**
 by [Jan Graefe](https://www.linkedin.com/in/jan-graefe-5b515b260/)
 (2024-04-28)
+
+- **["Level Up Your Serenity/JS Tests with WDIO Visual Regression Testing"](https://www.pilot-period.org/sjs-visual-wdio)**
+by [Jan Graefe](https://www.linkedin.com/in/jan-graefe-5b515b260/)
+(2024-03-24)
 
 - **["Reuse Component Test Code with BDD Scenarios using Serenity/JS and Playwright"](https://www.pilot-period.org/sjs-playwright-ct-cucumber)**
 by [Jan Graefe](https://www.linkedin.com/in/jan-graefe-5b515b260/)


### PR DESCRIPTION
Added 2 missing articles by Jan Graefe:
- "Open Letter to Jan Molak" (2026-06-04)
- "Level Up Your Serenity/JS Tests with WDIO Visual Regression Testing" (2024-03-24)

Jan Graefe now has 7 articles listed (up from 5). Articles are in reverse-chronological order.