### PR TITLE
docs: update getting-started guides to use HTML Reporter

### DIFF
--- a/src/docs/getting-started/cucumber.mdx
+++ b/src/docs/getting-started/cucumber.mdx
@@ -12,7 +12,9 @@ import TabItem from '@theme/TabItem';
 
 Already using Cucumber.js? Serenity/JS plugs right into your existing setup — with Playwright or WebdriverIO driving the browser.
 
-You keep Cucumber's Gherkin syntax, step definitions, and hooks. Serenity/JS adds the Screenplay Pattern, structured reporting, and multi-actor support that matter once your feature files outgrow a handful of scenarios.
+You keep Cucumber's Gherkin syntax, step definitions, and hooks. Serenity/JS adds the Screenplay Pattern, structured reporting, and multi-actor support that help your team understand what the system does and ship with confidence.
+
+→ New to Serenity/JS? Start with [Why Serenity/JS](/getting-started/) to see the full picture.
 
 ---
 
@@ -25,7 +27,7 @@ Here's how Serenity/JS helps you address common Cucumber challenges:
 | Challenge | How Serenity/JS helps |
 |---|---|
 | **Step definitions coupled to selectors** | The [Screenplay Pattern](/handbook/design/screenplay-pattern/) gives you composable Tasks that separate *what* from *how* |
-| **Reports show only pass/fail** | [Serenity BDD reports](/handbook/reporting/serenity-bdd-reporter/) generate living documentation organised by feature and capability |
+| **Reports show only pass/fail** | [Rich HTML reports](/handbook/reporting/html-reporter/) with trend tracking, flaky test detection, and living documentation organised by feature and capability |
 | **Multi-user workflows are awkward** | [Multi-actor support](/handbook/design/screenplay-pattern/) is built in — `actorCalled('Alice')` and `actorCalled('Bob')` in the same scenario |
 | **Step definitions are hard to reuse** | Screenplay Tasks are composable and portable — reuse them across step definitions, scenarios, and projects |
 | **Locked into one browser driver** | Screenplay Tasks work with both [Playwright](/api/playwright/) and [WebdriverIO](/api/webdriverio/) — switch without rewriting logic |
@@ -75,11 +77,11 @@ Create a `tsconfig.json`:
 ### Step 1: Install
 
 :::info Prerequisites
-You'll need a recent [Node.js LTS](https://nodejs.org/en/download/) version (Serenity/JS supports Node <SupportedNodeVersions conjunction="and" />), as well as [Java 11+](https://adoptium.net/) for the Serenity BDD reports.
+You'll need a recent [Node.js LTS](https://nodejs.org/en/download/) version (Serenity/JS supports Node <SupportedNodeVersions conjunction="and" />).
 :::
 
 ```sh npm2yarn
-npm install --save-dev @serenity-js/core @serenity-js/cucumber @serenity-js/web @serenity-js/assertions @serenity-js/playwright @serenity-js/console-reporter @serenity-js/serenity-bdd rimraf npm-failsafe playwright
+npm install --save-dev @serenity-js/core @serenity-js/cucumber @serenity-js/web @serenity-js/assertions @serenity-js/playwright @serenity-js/console-reporter @serenity-js/html-reporter playwright
 ```
 
 → Learn more: [Full Cucumber installation guide](/handbook/test-runners/cucumber/) | [Why Serenity/JS?](/getting-started/)
@@ -119,9 +121,8 @@ BeforeAll(async () => {
         ),
         crew: [
             '@serenity-js/console-reporter',
-            [ '@serenity-js/serenity-bdd', { specDirectory: './features' } ],
-            [ '@serenity-js/core:ArtifactArchiver', {
-                outputDirectory: './reports/serenity'
+            [ '@serenity-js/html-reporter', {
+                specDirectory: './features',
             } ],
         ],
     });
@@ -132,24 +133,17 @@ AfterAll(async () => {
 });
 ```
 
-Add the following scripts to your `package.json`:
-
-:::note Reading the diffs
-Lines marked with `+` should be added to your file; lines marked with `-` should be removed. Don't copy the `+`/`-` prefixes themselves.
-:::
+Add the following script to your `package.json`:
 
 ```diff title="package.json"
  {
    "scripts": {
-+    "clean": "rimraf target",
-+    "test": "failsafe clean test:execute [...] test:report",
-+    "test:execute": "cucumber-js",
-+    "test:report": "serenity-bdd run --features='./features' --source='./reports/serenity' --destination='./reports/serenity'"
++    "test": "cucumber-js"
    }
  }
 ```
 
-→ Learn more: [Cucumber configuration](/handbook/test-runners/cucumber/) | [Serenity BDD reporter setup](/handbook/reporting/serenity-bdd-reporter/) | [Using npm-failsafe](https://www.npmjs.com/package/npm-failsafe)
+→ Learn more: [Cucumber configuration](/handbook/test-runners/cucumber/) | [HTML Reporter setup](/handbook/reporting/html-reporter/)
 
 ### Step 3: Run
 
@@ -157,10 +151,10 @@ Lines marked with `+` should be added to your file; lines marked with `-` should
 npm test
 ```
 
-That's it. Your existing scenarios run as before, but now produce a rich HTML report in `reports/serenity/`. Open `reports/serenity/index.html` in your browser to view it.
+That's it. Your existing scenarios run as before, but now produce a rich HTML report in `reports/serenity-js/`. Open `reports/serenity-js/index.html` in your browser to view it.
 
 :::tip Running a single scenario
-The `[...]` wildcard in the `test` script is provided by [npm-failsafe](https://www.npmjs.com/package/npm-failsafe) and passes any arguments you provide directly to Cucumber. For example, to run scenarios by name:
+Pass any arguments directly to Cucumber via `npm test`. For example, to run scenarios by name:
 ```bash
 npm test -- --name="descriptive title"
 ```
@@ -170,12 +164,12 @@ npm test -- --tags="@smoke"
 ```
 :::
 
-→ Learn more: [Reporting overview](/handbook/reporting/) | [Serenity BDD reports](/handbook/reporting/serenity-bdd-reporter/)
+→ Learn more: [Reporting overview](/handbook/reporting/) | [HTML Reporter](/handbook/reporting/html-reporter/)
 
 <Figure
-    caption='Example Serenity BDD report generated by Serenity/JS'
-    img={require('@site/static/images/reporting/serenity-bdd-reporter.png')}
-    externalLink={'https://serenity-js.github.io/serenity-js-cucumber-playwright-template/'}
+    caption='Example HTML report generated by Serenity/JS'
+    img={require('@site/static/images/reporting/html-reporter-dashboard.png')}
+    externalLink={'https://serenity-js.github.io/serenity-js/'}
 />
 
 ### Step 4 (optional): Write your first Screenplay scenario
@@ -233,7 +227,7 @@ Then('{pronoun} should see that the page title includes {string}', async (actor:
 });
 ```
 
-Run `npm test` again. In the Serenity BDD report you'll now see each interaction ([`Navigate.to`](/api/web/class/Navigate), [`Ensure.that`](/api/assertions/class/Ensure)) listed as a separate step with timing.
+Run `npm test` again. In the HTML report you'll now see each interaction ([`Navigate.to`](/api/web/class/Navigate), [`Ensure.that`](/api/assertions/class/Ensure)) listed as a separate step with timing.
 
 The key differences from plain Cucumber step definitions:
 
@@ -252,7 +246,9 @@ Screenplay Tasks are identical whether you use Cucumber, Playwright Test, or Web
 
 ---
 
-## Reference projects
+## Go further
+
+Now that you've seen the basics, here are complete projects you can use as reference or as a starting point for your own.
 
 ### Complete example
 
@@ -260,7 +256,7 @@ A self-contained project you can copy in full. It includes:
 - `features/website.feature` — a simple Screenplay scenario using [`Navigate`](/api/web/class/Navigate) and [`Ensure`](/api/assertions/class/Ensure) (same pattern as Step 4)
 - `features/swag-labs.feature` — a more advanced scenario interacting with the [Swag Labs](https://www.saucedemo.com/) demo website, using composable [`Task`](/api/core/class/Task) definitions and the [Lean Page Objects pattern](/handbook/web-testing/page-objects-pattern/)
 
-Run `npm install` then `npm test` — the Serenity BDD HTML report lands in `reports/serenity/index.html`.
+Run `npm install` then `npm test` — the HTML report lands in `reports/serenity-js/index.html`.
 
 :::note Credentials in examples
 The password `secret_sauce` is hard-coded in these examples to keep them simple and self-contained. In real-world tests, load credentials from environment variables or a password vault to avoid committing secrets to your repository.
@@ -482,7 +478,7 @@ Yes. Replace `@serenity-js/playwright` with `@serenity-js/webdriverio` and confi
 
 ### Do I need Java?
 
-Yes, for the Serenity BDD HTML reports (Java 11+). If you'd rather stay Java-free, use the [console reporter](/handbook/reporting/console-reporter/) alone.
+Not if you use the [Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/) — it produces rich reports with trend tracking and flaky test detection using pure Node.js. Java is only needed for the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/).
 
 ### What Cucumber versions are supported?
 

--- a/src/docs/getting-started/electron.mdx
+++ b/src/docs/getting-started/electron.mdx
@@ -14,6 +14,8 @@ Building an Electron app? Serenity/JS lets you test it using the same Screenplay
 
 Under the hood, Serenity/JS leverages [Playwright's Electron support](https://playwright.dev/docs/electron) to connect to your app's renderer process. You get expressive tests, reusable interactions, and rich reporting — for desktop applications.
 
+→ New to Serenity/JS? Start with [Why Serenity/JS](/getting-started/) to see the full picture.
+
 ---
 
 ## Why add Serenity/JS?
@@ -69,14 +71,13 @@ npm init playwright@latest
 :::info Prerequisites
 To use Serenity/JS, you'll need:
 - A recent [Node.js LTS](https://nodejs.org/en/download/) version (Serenity/JS supports Node <SupportedNodeVersions conjunction="and" />)
-- [Java 11+](https://adoptium.net/) for the Serenity BDD reports
 - An existing Electron app to test (with [`electron`](https://www.npmjs.com/package/electron) as a dependency)
 :::
 
 From your Electron project directory, install Serenity/JS and Playwright Test:
 
 ```sh npm2yarn
-npm install --save-dev @serenity-js/core @serenity-js/assertions @serenity-js/playwright @serenity-js/playwright-test @serenity-js/web @serenity-js/console-reporter @serenity-js/serenity-bdd @playwright/test rimraf npm-failsafe
+npm install --save-dev @serenity-js/core @serenity-js/assertions @serenity-js/playwright @serenity-js/playwright-test @serenity-js/web @serenity-js/console-reporter @serenity-js/html-reporter @playwright/test
 ```
 
 → Learn more: [Full installation guide](/handbook/test-runners/playwright-test/installation/) | [Why Serenity/JS?](/getting-started/)
@@ -108,31 +109,25 @@ Lines marked with `+` should be added to your file; lines marked with `-` should
 +       [ '@serenity-js/playwright-test', {
 +           crew: [
 +               '@serenity-js/console-reporter',
-+               [ '@serenity-js/serenity-bdd', {
++               [ '@serenity-js/html-reporter', {
 +                   specDirectory: './spec'
-+               } ],
-+               [ '@serenity-js/core:ArtifactArchiver', {
-+                   outputDirectory: './reports/serenity'
 +               } ],
 +           ]
 +       }]
 +   ],
 ```
 
-Add the following scripts to your `package.json`:
+Add the following script to your `package.json`:
 
 ```diff title="package.json"
  {
    "scripts": {
-+    "clean": "rimraf target",
-+    "test": "failsafe clean test:execute [...] test:report",
-+    "test:execute": "npx playwright test",
-+    "test:report": "serenity-bdd run --features='./spec' --source='./reports/serenity' --destination='./reports/serenity'"
++    "test": "npx playwright test"
    }
  }
 ```
 
-→ Learn more: [Configuration options](/handbook/test-runners/playwright-test/configuration/) | [Serenity BDD reporter setup](/handbook/reporting/serenity-bdd-reporter/) | [Using npm-failsafe](https://www.npmjs.com/package/npm-failsafe)
+→ Learn more: [Configuration options](/handbook/test-runners/playwright-test/configuration/) | [HTML Reporter setup](/handbook/reporting/html-reporter/)
 
 ### Step 3: Write your first Electron test
 
@@ -175,16 +170,16 @@ describe('My Electron App', () => {
 npm test
 ```
 
-Your Electron app launches, the test runs, and you get a Serenity BDD report in `reports/serenity/`. Open `reports/serenity/index.html` in your browser to view it.
+Your Electron app launches, the test runs, and you get a rich HTML report automatically. Open `reports/serenity-js/index.html` in your browser to view it.
 
 :::tip Running a single test
-The `[...]` wildcard in the `test` script is provided by [npm-failsafe](https://www.npmjs.com/package/npm-failsafe) and passes any arguments you provide directly to Playwright Test. For example:
+Pass any arguments directly to Playwright Test. For example:
 ```bash
-npm test -- --grep="welcome screen"
+npx playwright test --grep="welcome screen"
 ```
 :::
 
-→ Learn more: [Reporting overview](/handbook/reporting/) | [Serenity BDD reports](/handbook/reporting/serenity-bdd-reporter/)
+→ Learn more: [Reporting overview](/handbook/reporting/) | [HTML Reporter](/handbook/reporting/html-reporter/)
 
 ---
 
@@ -266,7 +261,7 @@ No. Electron apps use their own Chromium instance. You don't need to install sep
 
 ### Do I need Java?
 
-Yes, for the Serenity BDD HTML reports (Java 11+). If you'd rather stay Java-free, use the [console reporter](/handbook/reporting/console-reporter/) alone or Playwright's built-in HTML report.
+Not if you use the [Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/) — it produces rich reports with trend tracking and flaky test detection using pure Node.js. Java is only needed for the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/).
 
 :::tip Something not working?
 Check the [Troubleshooting guide](/handbook/troubleshooting/) for solutions to common issues with reports, screenshots, and configuration.

--- a/src/docs/getting-started/index.mdx
+++ b/src/docs/getting-started/index.mdx
@@ -10,102 +10,94 @@ import TabItem from '@theme/TabItem';
 
 # Why Serenity/JS
 
-Serenity/JS helps your team evolve from writing test scripts to designing a **test automation system** — with the architecture, reporting, and reusability to scale your automation and adapt it as requirements change. The framework works as a layer on top of Playwright, WebdriverIO, or Cucumber, adding structure while reducing complexity and maintenance costs.
+Your test suite should be more than a collection of scripts that pass or fail. It should be **shared evidence** of what your system does, how reliably it does it, and whether it's ready to ship — evidence that developers, testers, and business stakeholders can all read and act on.
 
-To show you what that looks like in practice, this guide walks through the **same scenario** at four levels of Serenity/JS adoption — from a flat test script to structured, reusable code with rich reporting.
+That's what Serenity/JS helps you build.
 
-:::tip Works with multiple tools
-The examples below use [Playwright Test](/getting-started/playwright/), but everything shown here applies equally to [WebdriverIO](/getting-started/webdriverio/), [Cucumber](/getting-started/cucumber/), and other [supported test runners](/handbook/test-runners/). Screenplay Pattern code is **identical** regardless of what test runner or browser driver you use — that's the point of the architecture.
-:::
-
----
-
-## The problem with flat test scripts
-
-Most test suites start simple: a few specs, each one a sequence of clicks and assertions. That works — until the suite grows and the cracks show:
-
-- **Selectors duplicated everywhere** — a single UI change means updating dozens of files
-- **No reuse** — login logic is copy-pasted into every test that needs an authenticated user
-- **Reports show only pass/fail** — when something breaks, you're forced to read raw selectors to figure out what the test was trying to do
-- **Locked to one tool** — every line of code is coupled to a specific browser driver API
-
-The fix is the same one that works for production software: **separation of concerns** — keep *what* you're testing apart from *how* you're testing it.
+<Figure
+    caption='Serenity/JS HTML Report — shared evidence your whole team can act on'
+    img={require('@site/static/images/reporting/html-reporter-dashboard.png')}
+    externalLink={'https://serenity-js.github.io/serenity-js/'}
+/>
 
 ---
 
-## Layered test architecture
+## Tests and reports that explain your system
 
-As described in [BDD in Action, Second Edition](https://www.manning.com/books/bdd-in-action-second-edition), a well-structured test automation system has three layers:
+Most test reports list what's broken. Serenity/JS reports explain what your system **does** — and how confidently you can ship it:
 
-- **Specification layer** — *what* the system should do. Test scenarios expressed in business language.
-- **Domain layer** — *how* actors accomplish goals. Composable Tasks that use business vocabulary, independent of any integration tool.
-- **Integration layer** — *where* the system is interacted with. Low-level interactions with web UIs, APIs, or mobile apps through tool-specific drivers.
+- **For developers**: activity trees show the exact step that failed, with screenshots, HTTP exchanges, and timing — reducing diagnosis from minutes to seconds
+- **For QA engineers**: consistency tracking reveals which tests are genuinely broken vs. flaky vs. recovering — so you invest effort where it matters
+- **For product owners and managers**: the dashboard answers "can we ship?" with a confidence score, pass rate, and trend chart — no technical translation needed
+- **For the whole team**: the Capabilities view maps test results to your directory structure, turning your spec files into navigable living documentation of what the system does
 
-<figure>
+The [Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/) produces these reports automatically from your test results. But a report is only as meaningful as the tests behind it — which is where the Serenity/JS framework comes in.
 
-```mermaid
-flowchart TD
-    sut["System Under Test"]
+→ [See a live report](https://serenity-js.github.io/serenity-js/) | [HTML Reporter guide](/handbook/reporting/html-reporter/)
 
-    spec --> domain
-    domain --> integration
-    integration --> sut
+---
 
-    subgraph spec["Specification Layer"]
-        s1["Test scenarios, business rules, workflows"]
-    end
+## Tests expressed in domain language
 
-    subgraph domain["Domain Layer"]
-        d1["Tasks — business-level activities"]
-    end
+For reports to serve the whole team, tests need to describe **what the actors in your system are doing and why** — how a customer completes the checkout flow, how a third-party integrates with your APIs, how an administrator audits the system — not just how browsers click buttons or REST clients send requests.
 
-    subgraph integration["Integration Layer"]
-        web["Web\nIntegration"] ~~~ rest["REST API\nIntegration"] ~~~ mobile["Mobile\nIntegration"]
-    end
-```
+This requires tests to be written using the vocabulary of the business workflows they represent, with implementation details encapsulated so they don't pollute the test. As described in [BDD in Action, Second Edition](https://www.manning.com/books/bdd-in-action-second-edition), this separation naturally organises into three layers — and Serenity/JS gives you the building blocks to implement them:
 
-<figcaption>A layered test architecture separates business logic from integration details, making each layer independently maintainable.</figcaption>
-</figure>
+| Layer | Concern | Serenity/JS concept |
+|-------|---------|---------------------|
+| **Specification** | *What* the system should do | Test scenarios (`describe`, `it`) |
+| **Domain** | *How* actors accomplish goals — composable workflows in business language | [Actors](/api/core/class/Actor/) + [Tasks](/api/core/class/Task/) |
+| **Integration** | *Where* the system is interacted with — web UIs, APIs, mobile apps | [Abilities](/api/core/class/Ability/) + [Interactions](/api/core/class/Interaction/) + [Questions](/api/core/class/Question/) |
 
-Each layer depends only on the layer below it, so when something in the system under test changes, only the affected layer needs updating. For example, a UI redesign means new selectors in the Integration layer — but your Domain Tasks and Specification scenarios stay untouched:
+Each layer depends only on the layer below it, so when something changes, the impact stays contained:
 
-| What changes | What you update | What stays the same |
-|---|---|---|
-| UI redesign | Integration layer (selectors) | Domain + Specification |
-| New business rule | Specification + Domain | Integration |
-| Switch Playwright → WebdriverIO | Integration config | Domain + Specification |
-| Add API testing | Integration layer | Domain + Specification |
-
-In Serenity/JS, these layers map directly to framework concepts you'll use every day:
-
-| Layer | Serenity/JS concept | Example |
-|---|---|---|
-| Specification | Test scenarios (`describe`, `it`) | `it('should let a user complete checkout', ...)` |
-| Domain | [Actors](/api/core/class/Actor/) + [Tasks](/api/core/class/Task/) | `actor.attemptsTo(Checkout.completeWith(...))` |
-| Integration | [Abilities](/api/core/class/Ability/) + [Interactions](/api/core/class/Interaction/) + [Questions](/api/core/class/Question/) | `Click.on(...)`, `Text.of(...)`, `PageElement.located(...)` |
+- **UI redesign** — update selectors in the Integration layer; your business workflows and test scenarios don't change
+- **New business rule** — add scenarios and Tasks; the integration code stays the same
+- **Switch Selenium → Playwright** — swap the configuration; your Tasks and specs are untouched
+- **Change integration APIs** — update the Integration layer; nothing above it notices
 
 → Learn more: [Screenplay Pattern](/handbook/design/screenplay-pattern/) | [Serenity/JS Architecture](/handbook/architecture/) | [BDD in Action, Second Edition](https://www.manning.com/books/bdd-in-action-second-edition)
 
 ---
 
-## Levels of adoption
+## The Screenplay Pattern makes this practical
 
-The following scenario is implemented at four levels of Serenity/JS adoption — from vanilla Playwright and no Serenity/JS, through to the full Serenity/JS Screenplay Pattern implementation. Each level builds on the previous one, and you can stop wherever it makes sense for your project.
+The [Screenplay Pattern](/handbook/design/screenplay-pattern/) is the architectural mechanism that makes domain-language tests possible without ceremony or heavyweight abstractions:
 
-**The scenario:** A "standard user" logs in to [Swag Labs](https://www.saucedemo.com/), adds a "Sauce Labs Backpack" to their cart, completes checkout, and verifies the order confirmation.
+- **Actors** represent people and external systems interacting with the system under test
+- **Abilities** are thin wrappers around integration libraries needed to interact with your system's interfaces
+- **Tasks** model sequences of activities as meaningful steps of a business workflow
+- **Interactions** represent the low-level activities an actor can perform using a given interface
+- **Questions** retrieve information from the system under test and the test execution environment
+
+The same Tasks and Questions work across [Playwright](/getting-started/playwright/), [WebdriverIO](/getting-started/webdriverio/), [Cucumber](/getting-started/cucumber/), and other [supported test runners](/handbook/test-runners/) — because they depend on abstractions, not on any specific integration library.
+
+:::tip Works with multiple tools
+The examples below use [Playwright Test](/getting-started/playwright/), but Screenplay Pattern code is **identical** regardless of what test runner or browser driver you use — that's the point of the architecture.
+:::
+
+---
+
+## Adopt at your own pace
+
+Serenity/JS draws on over two decades of the author's experience helping teams of all sizes — from startups shipping MVP webapps to multinationals building online banking systems and sophisticated trading platforms. We know that no team can stop delivering to rearchitect their test suite. That's why Serenity/JS supports gradual adoption: start with just reporting, introduce Screenplay interactions where they add value, and let new and legacy tests run side by side — no migration deadline required.
+
+To show you how this works in practice, here's the same test at four levels of adoption, from vanilla Playwright through to the full Screenplay Pattern.
+
+**Scenario: Existing Swag Labs customer successfully orders an item**
+
+- Customer logs in
+- Adds a backpack to their cart
+- Successfully completes checkout
 
 :::tip About Swag Labs
 [Swag Labs](https://www.saucedemo.com/) is a demo e-commerce website created by [Sauce Labs](https://saucelabs.com/) specifically for practicing test automation.
 It's a fictive online store where you can browse products, add items to a cart, and complete checkout flows.
 :::
 
-:::note Credentials in examples
-The password `secret_sauce` is hard-coded in these examples to keep them simple and self-contained. In real-world tests, load credentials from environment variables or a password vault to avoid committing secrets to your repository.
-:::
+### Level 0: Where most teams start
 
-### Level 0: Vanilla Playwright
-
-This is the starting point most teams are familiar with — no Serenity/JS, all logic in one flat script.
+No Serenity/JS — all logic in flat test scripts. This is where most teams start — and where most test suites stay until the pain of duplication and opaque failures forces a change.
 
 ```typescript title="tests/checkout.spec.ts"
 import { test, expect } from '@playwright/test';
@@ -138,12 +130,19 @@ test('should complete checkout successfully', async ({ page }) => {
 - **Selector duplication** — when `[data-test="login-button"]` becomes `[data-test="sign-in"]`, you grep the codebase and update every file that references it. With 200 tests and 30 that need login, that's 30 edits for one rename.
 - **Opaque failures** — reports show "failed at locator `[data-test="login-button"]`". To understand *what* the test was verifying, you have to mentally parse the whole script.
 - **No reuse** — login, "add to cart", checkout — each sequence is copy-pasted into every test that needs it.
+- **AI amplifies the problem** — coding agents trained on your codebase reproduce the same copy-paste patterns, generating more tests with the same duplication and fragility, faster than you can review their changes.
+
+:::note Credentials in examples
+The password `secret_sauce` is hard-coded in these examples to keep them simple and self-contained. In real-world tests, load credentials from environment variables or a password vault to avoid committing secrets to your repository.
+:::
 
 ---
 
 ### Level 1: Add Serenity/JS reporting
 
-The smallest possible improvement: add Serenity/JS reporters to your `playwright.config.ts`. Your test code stays completely unchanged, but the reports now organise results by capability and feature — [derived from your file naming conventions and directory structure](/handbook/reporting/serenity-bdd-reporter/#serenity-bdd-best-practices) — rather than showing a flat list of pass/fail.
+The smallest possible improvement: add the [Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/) to your test runner configuration. Your test code stays completely unchanged, but the reports now show trend history across CI runs, flaky test detection, error clustering, and an interactive dashboard — all in a self-contained report you can open directly from your filesystem, or serve from [GitHub Pages](/handbook/integration/github-actions/) or [GitLab Pages](/handbook/integration/gitlab-ci/).
+
+For example, with Playwright Test:
 
 ```diff title="playwright.config.ts"
   import { defineConfig, devices } from '@playwright/test';
@@ -156,11 +155,8 @@ The smallest possible improvement: add Serenity/JS reporters to your `playwright
 +         [ '@serenity-js/playwright-test', {
 +             crew: [
 +                 '@serenity-js/console-reporter',
-+                 [ '@serenity-js/serenity-bdd', {
++                 [ '@serenity-js/html-reporter', {
 +                     specDirectory: './tests'
-+                 } ],
-+                 [ '@serenity-js/core:ArtifactArchiver', {
-+                     outputDirectory: './reports/serenity'
 +                 } ],
 +             ]
 +         }]
@@ -169,35 +165,26 @@ The smallest possible improvement: add Serenity/JS reporters to your `playwright
   });
 ```
 
-Next, update your `package.json` scripts to generate the Serenity BDD HTML report after test execution:
+That's it — no separate report generation step, no additional scripts. The report is produced automatically at the end of the test run.
 
-```diff title="package.json"
- {
-   "scripts": {
-+    "clean": "rimraf target",
-+    "test": "failsafe clean test:execute [...] test:report",
-+    "test:execute": "npx playwright test",
-+    "test:report": "serenity-bdd run --features='./tests' --source='./reports/serenity' --destination='./reports/serenity'"
-   }
- }
-```
-
-→ Learn more: [Using npm-failsafe](https://www.npmjs.com/package/npm-failsafe) | [Configuring the test runner](/handbook/reporting/serenity-bdd-reporter/#configuring-the-test-runner)
+→ Learn more: [HTML Reporter configuration](/handbook/reporting/html-reporter/#configuration) | [Configuring the test runner](/handbook/reporting/html-reporter/#playwright-test)
 
 **What you gain:**
-- Test results grouped by feature and capability rather than a flat list
-- [Serenity BDD living documentation](/handbook/reporting/serenity-bdd-reporter/) that stakeholders can explore by feature and capability
-- **Zero changes to your test code** — only the config and scripts are updated
+- **Trend history** — see how pass rate and duration change across CI runs; spot regressions immediately
+- **Flaky test detection** — tests automatically classified as flaky, degraded, inconsistent, or recovered
+- **Error clustering** — failures grouped by root cause, not listed individually
+- **Interactive dashboard** — confidence score, pass rate, completeness, and consistency at a glance
+- **Zero changes to your test code** — only the config is updated
 
 **What still breaks down at scale:**
 - **Selectors still duplicated** — a UI refactor still means a multi-file find-and-replace
 - **No code reuse** — login logic is still copy-pasted into every test that needs an authenticated user
-- **Diagnosis gap** — reports tell you *which* test failed, but the test code itself still can't tell you *why* at a glance
+- **Diagnosis gap** — reports tell you *which* test failed and cluster errors, but the test code itself still can't show you the *step-by-step execution* at a glance
 
 <Figure
-    caption='Example Serenity BDD report generated by Serenity/JS'
-    img={require('@site/static/images/reporting/serenity-bdd-reporter.png')}
-    externalLink={'https://serenity-js.github.io/serenity-js-cucumber-playwright-template/'}
+    caption='Serenity/JS HTML Report — Dashboard with trend chart and KPI cards'
+    img={require('@site/static/images/reporting/html-reporter-dashboard.png')}
+    externalLink={'https://serenity-js.github.io/serenity-js/'}
 />
 
 → [Set this up in 5 minutes](/getting-started/playwright/#step-1-install)
@@ -206,7 +193,7 @@ Next, update your `package.json` scripts to generate the Serenity BDD HTML repor
 
 ### Level 2: Screenplay + Playwright hybrid
 
-Here you start using Serenity/JS fixtures alongside your existing Playwright code. Swap the import to `@serenity-js/playwright-test` to access the `actor` fixture, then introduce Screenplay interactions where they add clarity — existing tests stay as they are.
+Now that you have reporting, the next step is making your tests *produce better reports*. Swap the import to `@serenity-js/playwright-test` to access the `actor` fixture, then introduce Screenplay interactions where they add clarity. Each interaction appears as a named, timed step in the report — and your existing tests continue to work unchanged alongside the new ones.
 
 ```typescript title="tests/checkout.spec.ts"
 import { test, expect } from '@serenity-js/playwright-test';  // ← swap the import
@@ -241,6 +228,7 @@ test('should complete checkout successfully', async ({ actor, page }) => {
 **What you gain over Level 1:**
 - Screenplay interactions appear as named steps in reports — with timing and screenshots
 - Access to `actor`, `actorCalled`, and other [Serenity/JS fixtures](/api/playwright-test/interface/SerenityFixtures/)
+- A library of ready-made interactions — [`Navigate`](/api/web/class/Navigate/), [`Click`](/api/web/class/Click/), [`Enter`](/api/web/class/Enter/), and [many more](/api/web/)
 - Incremental adoption — convert interactions one at a time without rewriting entire tests
 
 **What still breaks down at scale:**
@@ -252,7 +240,7 @@ test('should complete checkout successfully', async ({ actor, page }) => {
 
 ### Level 3: Full Screenplay Pattern
 
-At this level, tests describe *what the user does* in business language. Selectors, page interactions, and API calls live in separate, reusable classes that any test can compose. Compare the spec file below with the flat script from Level 0:
+This is where the architecture pays off in full. Tests describe *what the actors do* in business language — and the report reflects that directly. Selectors, page interactions, and API calls live in separate, reusable classes that any test can compose. Compare the spec file below with the flat script from Level 0:
 
 <Tabs>
 <TabItem value="spec" label="swag-labs.spec.ts" default>
@@ -411,9 +399,8 @@ export class Checkout {
 
 **What you gain over Levels 1–2:**
 - **Readable tests** — the scenario reads like a user story, not a browser script
-- **Reusable building blocks** — `Authenticate.withCredentials()` works in every test; change a selector once, fix it everywhere
-- **Rich activity breakdown** — reports show "completes checkout" → "proceeds to checkout" → "clicks on checkout button", with timing at each step
-- **Masked credentials** — sensitive values appear as `[MASKED]` in reports (see the `Authenticate.ts` tab above)
+- **Reusable building blocks** — `Authenticate.withCredentials()` works in every test; change a selector once, fix every test that needs it
+- **Rich activity breakdown** — reports decompose high-level Tasks into their constituent steps, each with timing and evidence, so you can trace exactly where a workflow succeeded or failed
 - **Multi-actor support** — buyer + seller, admin + user scenarios become [trivial to implement](/handbook/test-runners/playwright-test/multi-actor-scenarios/)
 - **[Blended testing](/handbook/web-testing/blended-testing/)** — use APIs for fast test data setup, UI only where it matters
 - **Tool independence** — swap Playwright for WebdriverIO, or use both in the same project, without touching test logic
@@ -426,28 +413,14 @@ The Task code imports from [`@serenity-js/web`](/api/web/) and [`@serenity-js/co
 
 ---
 
-## How to start
+## Ready to start?
 
-The most common adoption path:
-
-**Level 1 — reporting.** Add Serenity/JS reporters to your config. No test code changes, immediate value from structured reports.
-
-**Level 2 — hybrid.** Swap the import and start using `actor` alongside `page`. Convert interactions one at a time where they add clarity.
-
-**Level 3 — new tests.** Write new scenarios with composable Tasks from the start. Migrate existing tests when they become painful to maintain.
-
-**Beyond Level 3 — [blended testing](/handbook/web-testing/blended-testing/).** Use API interactions for test data setup while testing through the UI only where it demonstrates value. The same Task can have a fast API-based implementation for preconditions and a thorough UI-based one for the scenario you're verifying.
-
-All levels coexist in the same project — you're in control of how far and how fast you go. There's no big-bang rewrite.
-
----
-
-## Ready to try Serenity/JS?
+Pick the guide for your test runner — each one takes you from zero to a working report in under 5 minutes:
 
 - **[For Playwright users](/getting-started/playwright/)** — add Serenity/JS to your project in 5 minutes
 - **[For WebdriverIO users](/getting-started/webdriverio/)** — integrate with your existing setup
 - **[For Cucumber users](/getting-started/cucumber/)** — add reporting and Screenplay to your Gherkin scenarios
-- **[15-minute tutorial](/handbook/tutorials/your-first-web-scenario/)** — build your first Screenplay test
+- **[15-minute tutorial](/handbook/tutorials/your-first-web-scenario/)** — build your first Screenplay test step by step, from scratch
 - **[Project Templates](/getting-started/project-templates/)** — pre-configured starter projects
 
 ### What others are saying

--- a/src/docs/getting-started/playwright.mdx
+++ b/src/docs/getting-started/playwright.mdx
@@ -12,7 +12,9 @@ import TabItem from '@theme/TabItem';
 
 Already using Playwright Test? Good — Serenity/JS is built to work **on top of it**, not instead of it.
 
-You keep Playwright's speed, auto-waiting, tracing, and parallel execution. Serenity/JS adds the structure and reporting that matter once your test suite outgrows a handful of specs.
+You keep Playwright's speed, auto-waiting, tracing, and parallel execution. Serenity/JS adds the architecture and reporting that help your team understand what the system does and ship with confidence.
+
+→ New to Serenity/JS? Start with [Why Serenity/JS](/getting-started/) to see the full picture.
 
 ---
 
@@ -27,7 +29,7 @@ Here's how Serenity/JS helps you address common Playwright Test challenges:
 | **Duplicated selectors and test logic** | The [Screenplay Pattern](/handbook/design/screenplay-pattern/) gives you composable, reusable Tasks that separate *what* from *how* |
 | **Hard to tell what a test did** | [Structured reports](/handbook/reporting/) show every action, with timing and screenshots |
 | **Multi-user workflows are hard to implement** | [Multi-actor support](/handbook/test-runners/playwright-test/multi-actor-scenarios/) is built in |
-| **Stakeholders can't read test reports** | [Serenity BDD reports](/handbook/reporting/serenity-bdd-reporter/) generate living documentation for both technical and business audiences |
+| **Stakeholders can't read test reports** | [Serenity/JS HTML Report](/handbook/reporting/html-reporter/) for all stakeholders — developers, testers, and business audiences — with trend tracking, flaky test detection, and execution evidence |
 | **Logic duplicated across API and UI tests** | Screenplay Tasks [work across interfaces](/handbook/web-testing/blended-testing/) |
 | **Slow UI-only test suites** | [Blended testing](/handbook/web-testing/blended-testing/) — use APIs for setup, UI only where it matters |
 | **Locked into one tool** | Screenplay Tasks are portable — switch integration tools and test runners without rewriting test logic |
@@ -69,11 +71,11 @@ npm init playwright@latest
 ### Step 1: Install
 
 :::info Prerequisites
-To use Serenity/JS, you'll need a recent [Node.js LTS](https://nodejs.org/en/download/) version — Serenity/JS supports Node <SupportedNodeVersions conjunction="and" />, as well as [Java 11+](https://adoptium.net/) for the Serenity BDD reports.
+To use Serenity/JS, you'll need a recent [Node.js LTS](https://nodejs.org/en/download/) version — Serenity/JS supports Node <SupportedNodeVersions conjunction="and" />.
 :::
 
 ```sh npm2yarn
-npm install --save-dev @serenity-js/core @serenity-js/console-reporter @serenity-js/playwright @serenity-js/playwright-test @serenity-js/rest @serenity-js/web @serenity-js/serenity-bdd rimraf npm-failsafe
+npm install --save-dev @serenity-js/core @serenity-js/console-reporter @serenity-js/playwright @serenity-js/playwright-test @serenity-js/rest @serenity-js/web @serenity-js/html-reporter
 ```
 
 → Learn more: [Full installation guide](/handbook/test-runners/playwright-test/installation/) | [Why Serenity/JS?](/getting-started/)
@@ -105,31 +107,25 @@ Lines marked with `+` should be added to your file; lines marked with `-` should
 +       [ '@serenity-js/playwright-test', {
 +           crew: [
 +               '@serenity-js/console-reporter',
-+               [ '@serenity-js/serenity-bdd', {
++               [ '@serenity-js/html-reporter', {
 +                   specDirectory: './tests'
-+               } ],
-+               [ '@serenity-js/core:ArtifactArchiver', {
-+                   outputDirectory: './reports/serenity'
 +               } ],
 +           ]
 +       }]
 +   ],
 ```
 
-Next, add the following scripts to your `package.json`:
+Next, add the following script to your `package.json`:
 
 ```diff title="package.json"
  {
    "scripts": {
-+    "clean": "rimraf target",
-+    "test": "failsafe clean test:execute [...] test:report",
-+    "test:execute": "npx playwright test",
-+    "test:report": "serenity-bdd run --features='./tests' --source='./reports/serenity' --destination='./reports/serenity'"
++    "test": "npx playwright test"
    }
  }
 ```
 
-→ Learn more: [Configuration options](/handbook/test-runners/playwright-test/configuration/) | [Serenity BDD reporter setup](/handbook/reporting/serenity-bdd-reporter/) | [Using npm-failsafe](https://www.npmjs.com/package/npm-failsafe)
+→ Learn more: [Configuration options](/handbook/test-runners/playwright-test/configuration/) | [HTML Reporter setup](/handbook/reporting/html-reporter/)
 
 ### Step 3: Change one import
 
@@ -148,25 +144,25 @@ In your test files:
 npm test
 ```
 
-That's it. Your existing tests run as before, but now produce a rich HTML report in `reports/serenity/`. Open `reports/serenity/index.html` in your browser to view it.
+That's it. Your existing tests run as before, but now produce a rich HTML report automatically at the end of the test run. Open `reports/serenity-js/index.html` in your browser to view it.
 
 :::tip Running a single test
-The `[...]` wildcard in the `test` script is provided by [npm-failsafe](https://www.npmjs.com/package/npm-failsafe) and passes any arguments you provide directly to Playwright Test. For example, to run a single spec file:
+Pass any arguments directly to Playwright Test. For example, to run a single spec file:
 ```bash
-npm test -- --spec=tests/website.spec.ts
+npx playwright test tests/website.spec.ts
 ```
 Or to run tests matching a specific name:
 ```bash
-npm test -- --grep="descriptive title"
+npx playwright test --grep="descriptive title"
 ```
 :::
 
-→ Learn more: [Reporting overview](/handbook/reporting/) | [Serenity BDD reports](/handbook/reporting/serenity-bdd-reporter/)
+→ Learn more: [Reporting overview](/handbook/reporting/) | [HTML Reporter](/handbook/reporting/html-reporter/)
 
 <Figure
-    caption='Example Serenity BDD report generated by Serenity/JS'
-    img={require('@site/static/images/reporting/serenity-bdd-reporter.png')}
-    externalLink={'https://serenity-js.github.io/serenity-js-playwright-test-template/serenity/'}
+    caption='Example Serenity/JS HTML report'
+    img={require('@site/static/images/reporting/html-reporter-dashboard.png')}
+    externalLink={'https://serenity-js.github.io/serenity-js/'}
 />
 
 ### Step 5 (optional): Write your first Screenplay test
@@ -192,7 +188,7 @@ describe('Website', () => {
 });
 ```
 
-Run `npm test` again. In the Serenity BDD report you'll now see each interaction ([`Navigate.to`](/api/web/class/Navigate), [`Ensure.that`](/api/assertions/class/Ensure)) listed as a separate step with timing — giving you a clear activity breakdown without any extra configuration.
+Run `npm test` again. In the HTML report you'll now see each interaction ([`Navigate.to`](/api/web/class/Navigate), [`Ensure.that`](/api/assertions/class/Ensure)) listed as a separate step with timing — giving you a clear activity breakdown without any extra configuration.
 
 This test does the same thing as the generated `example.spec.ts`, but uses the `actor` fixture and Screenplay interactions instead of `page` directly. The key differences:
 
@@ -210,7 +206,9 @@ See the [full installation guide](/handbook/test-runners/playwright-test/install
 
 ---
 
-## Reference projects
+## Go further
+
+Now that you've seen the basics, here are complete projects you can use as reference or as a starting point for your own.
 
 ### Complete example
 
@@ -218,7 +216,7 @@ A self-contained project you can copy in full. It includes:
 - `tests/website.spec.ts` — a simple Screenplay test using [`Navigate`](/api/web/class/Navigate) and [`Ensure`](/api/assertions/class/Ensure) (same pattern as Step 5)
 - `tests/swag-labs.spec.ts` — a more advanced test interacting with the [Swag Labs](https://www.saucedemo.com/) demo website, using composable [`Task`](/api/core/class/Task) definitions and the [Lean Page Objects pattern](/handbook/web-testing/page-objects-pattern/)
 
-Run `npm install` then `npm test` — the Serenity BDD HTML report lands in `reports/serenity/index.html`.
+Run `npm install` then `npm test` — the HTML report lands in `reports/serenity-js/index.html`.
 
 :::note Credentials in examples
 The password `secret_sauce` is hard-coded in these examples to keep them simple and self-contained. In real-world tests, load credentials from environment variables or a password vault to avoid committing secrets to your repository.
@@ -230,22 +228,17 @@ The password `secret_sauce` is hard-coded in these examples to keep them simple 
 <DynamicPackageJson
     name="my-serenity-js-project"
     scripts={{
-        "clean": "rimraf target",
-        "test": "failsafe clean test:execute [...] test:report",
-        "test:execute": "npx playwright test",
-        "test:report": "serenity-bdd run --features='./tests' --source='./reports/serenity' --destination='./reports/serenity'"
+        "test": "npx playwright test"
     }}
     devDependencies={[
         "@serenity-js/assertions",
         "@serenity-js/console-reporter",                                   
         "@serenity-js/core",
+        "@serenity-js/html-reporter",
         "@serenity-js/playwright",
         "@serenity-js/playwright-test",
-        "@serenity-js/serenity-bdd",
         "@serenity-js/web",
         "@playwright/test",
-        [ "npm-failsafe", "^1.4.0" ],
-        [ "rimraf", "^6.0.0" ],
         [ "typescript", "^5.7.0" ],
     ]}
 />
@@ -263,11 +256,8 @@ export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
         [ '@serenity-js/playwright-test', {
             crew: [
                 '@serenity-js/console-reporter',
-                [ '@serenity-js/serenity-bdd', { 
+                [ '@serenity-js/html-reporter', { 
                     specDirectory: './tests' 
-                } ],
-                [ '@serenity-js/core:ArtifactArchiver', { 
-                    outputDirectory: './reports/serenity' 
                 } ],
             ]
         }]
@@ -469,7 +459,7 @@ Serenity/JS extends Playwright Test fixtures — it doesn't replace them. You st
 
 ### Do I need Java?
 
-Yes, for the Serenity BDD HTML reports (Java 11+). If you'd rather stay Java-free, use the [console reporter](/handbook/reporting/console-reporter/) alone or Playwright's built-in HTML report.
+Not if you use the [Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/) — it produces rich reports with trend tracking, flaky test detection, and execution history using pure Node.js. Java is only needed if you choose to use the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/).
 
 :::tip Something not working?
 Check the [Troubleshooting guide](/handbook/troubleshooting/) for solutions to common issues with reports, screenshots, and configuration.

--- a/src/docs/getting-started/webdriverio.mdx
+++ b/src/docs/getting-started/webdriverio.mdx
@@ -12,7 +12,9 @@ import TabItem from '@theme/TabItem';
 
 Already using WebdriverIO? Serenity/JS plugs right into your existing setup — Mocha, Cucumber, or Jasmine, your choice.
 
-You keep WebdriverIO's cross-browser support, WebDriver protocol compliance, and mobile testing capabilities. Serenity/JS brings the structure and reporting that matter once your test suite outgrows a handful of specs.
+You keep WebdriverIO's cross-browser support, WebDriver protocol compliance, and mobile testing capabilities. Serenity/JS adds the architecture and reporting that help your team understand what the system does and ship with confidence.
+
+→ New to Serenity/JS? Start with [Why Serenity/JS](/getting-started/) to see the full picture.
 
 ---
 
@@ -26,7 +28,7 @@ Here's how Serenity/JS helps you address common WebdriverIO challenges:
 |---|---|
 | **Duplicated selectors and test logic** | The [Screenplay Pattern](/handbook/design/screenplay-pattern/) gives you composable, reusable Tasks that separate *what* from *how* |
 | **Reports show only pass/fail** | [Structured reports](/handbook/reporting/) show every action, with timing and screenshots |
-| **Stakeholders can't read test reports** | [Serenity BDD reports](/handbook/reporting/serenity-bdd-reporter/) generate living documentation for both technical and business audiences |
+| **Stakeholders can't read test reports** | [Serenity/JS HTML Report](/handbook/reporting/html-reporter/) for all stakeholders — developers, testers, and business audiences — with trend tracking, flaky test detection, and execution evidence |
 | **Logic duplicated across API and UI tests** | Screenplay Tasks [work across interfaces](/handbook/web-testing/blended-testing/) |
 | **Slow UI-only test suites** | [Blended testing](/handbook/web-testing/blended-testing/) — use APIs for setup, UI only where it matters |
 | **Locked into one tool** | Screenplay Tasks are portable — switch to Playwright without rewriting test logic |
@@ -78,11 +80,11 @@ If you selected a **"with Serenity/JS"** framework option in the wizard, Steps 1
 ### Step 1: Install
 
 :::info Prerequisites
-You'll need a recent [Node.js LTS](https://nodejs.org/en/download/) version (Serenity/JS supports Node <SupportedNodeVersions conjunction="and" />), as well as [Java 11+](https://adoptium.net/) for the Serenity BDD reports.
+You'll need a recent [Node.js LTS](https://nodejs.org/en/download/) version (Serenity/JS supports Node <SupportedNodeVersions conjunction="and" />).
 :::
 
 ```sh npm2yarn
-npm install --save-dev @serenity-js/core @serenity-js/webdriverio @serenity-js/web @serenity-js/assertions @serenity-js/console-reporter @serenity-js/serenity-bdd @serenity-js/mocha rimraf npm-failsafe
+npm install --save-dev @serenity-js/core @serenity-js/webdriverio @serenity-js/web @serenity-js/assertions @serenity-js/console-reporter @serenity-js/html-reporter @serenity-js/mocha
 ```
 
 → Learn more: [Full WebdriverIO installation guide](/handbook/test-runners/webdriverio/) | [Why Serenity/JS?](/getting-started/)
@@ -108,52 +110,46 @@ Lines marked with `+` should be added to your file; lines marked with `-` should
 +       runner: 'mocha',
 +       crew: [
 +           '@serenity-js/console-reporter',
-+           [ '@serenity-js/serenity-bdd', { specDirectory: './test/specs' } ],
-+           [ '@serenity-js/core:ArtifactArchiver', {
-+               outputDirectory: './target/site/serenity'
-+           } ],
++           [ '@serenity-js/html-reporter', { specDirectory: './test/specs' } ],
 +       ],
 +   },
     // ... keep your existing settings ...
 -   framework: 'mocha',
 ```
 
-Next, add the following scripts to your `package.json`:
+Next, add the following script to your `package.json`:
 
 ```diff title="package.json"
  {
    "scripts": {
-+    "serenity": "failsafe serenity:clean wdio [...] serenity:report",
-+    "serenity:clean": "rimraf target",
-+    "wdio": "wdio run ./wdio.conf.ts",
-+    "serenity:report": "serenity-bdd run --features='./test/specs'"
++    "test": "wdio run ./wdio.conf.ts"
    }
  }
 ```
 
-→ Learn more: [WebdriverIO configuration](/handbook/test-runners/webdriverio/) | [Serenity BDD reporter setup](/handbook/reporting/serenity-bdd-reporter/) | [Using npm-failsafe](https://www.npmjs.com/package/npm-failsafe)
+→ Learn more: [WebdriverIO configuration](/handbook/test-runners/webdriverio/) | [HTML reporter setup](/handbook/reporting/html-reporter/)
 
 ### Step 3: Run
 
 ```bash
-npm run serenity
+npm test
 ```
 
-That's it. Your existing tests run as before, but now produce a rich HTML report in `target/site/serenity/`. Open `target/site/serenity/index.html` in your browser to view it.
+That's it. Your existing tests run as before, but now produce a rich HTML report automatically at the end of the test run. Open `reports/serenity-js/index.html` in your browser to view it.
 
 :::tip Running a single test
-The `[...]` wildcard in the `serenity` script is provided by [npm-failsafe](https://www.npmjs.com/package/npm-failsafe) and passes any arguments you provide directly to WebdriverIO. For example, to run a single spec file:
+Pass any additional arguments directly to WebdriverIO. For example, to run a single spec file:
 ```bash
-npm run serenity -- --spec=test/specs/website.spec.ts
+npx wdio run ./wdio.conf.ts --spec=test/specs/website.spec.ts
 ```
 :::
 
-→ Learn more: [Reporting overview](/handbook/reporting/) | [Serenity BDD reports](/handbook/reporting/serenity-bdd-reporter/)
+→ Learn more: [Reporting overview](/handbook/reporting/) | [HTML Reporter](/handbook/reporting/html-reporter/) | [Serenity BDD reports](/handbook/reporting/serenity-bdd-reporter/)
 
 <Figure
-    caption='Example Serenity BDD report generated by Serenity/JS'
-    img={require('@site/static/images/reporting/serenity-bdd-reporter.png')}
-    externalLink={'https://serenity-js.github.io/serenity-js-mocha-webdriverio-template/'}
+    caption='Example Serenity/JS HTML report'
+    img={require('@site/static/images/reporting/html-reporter-dashboard.png')}
+    externalLink={'https://serenity-js.github.io/serenity-js/'}
 />
 
 ### Step 4 (optional): Write your first Screenplay test
@@ -180,7 +176,7 @@ describe('Website', () => {
 });
 ```
 
-Run `npm run serenity` again. In the Serenity BDD report you'll now see each interaction ([`Navigate.to`](/api/web/class/Navigate), [`Ensure.that`](/api/assertions/class/Ensure)) listed as a separate step with timing — giving you a clear activity breakdown without any extra configuration.
+Run `npm test` again. In the report you'll now see each interaction ([`Navigate.to`](/api/web/class/Navigate), [`Ensure.that`](/api/assertions/class/Ensure)) listed as a separate step with timing — giving you a clear activity breakdown without any extra configuration.
 
 This test uses [`actorCalled`](/api/core/function/actorCalled) and Screenplay interactions instead of WebdriverIO's `browser` object directly. The key differences:
 
@@ -198,7 +194,9 @@ Screenplay code is identical whether you use Playwright or WebdriverIO — only 
 
 ---
 
-## Reference projects
+## Go further
+
+Now that you've seen the basics, here are complete projects you can use as reference or as a starting point for your own.
 
 ### Complete example
 
@@ -206,7 +204,7 @@ A self-contained project you can copy in full. It includes:
 - `test/specs/website.spec.ts` — a simple Screenplay test using [`Navigate`](/api/web/class/Navigate) and [`Ensure`](/api/assertions/class/Ensure) (same pattern as Step 4)
 - `test/specs/swag-labs.spec.ts` — a more advanced test interacting with the [Swag Labs](https://www.saucedemo.com/) demo website, using composable [`Task`](/api/core/class/Task) definitions and the [Lean Page Objects pattern](/handbook/web-testing/page-objects-pattern/)
 
-Run `npm install` then `npm run serenity` — the Serenity BDD HTML report lands in `target/site/serenity/index.html`.
+Run `npm install` then `npm test` — the HTML report lands in `reports/serenity-js/index.html`.
 
 :::note Credentials in examples
 The password `secret_sauce` is hard-coded in these examples to keep them simple and self-contained. In real-world tests, load credentials from environment variables or a password vault to avoid committing secrets to your repository.
@@ -218,23 +216,18 @@ The password `secret_sauce` is hard-coded in these examples to keep them simple 
 <DynamicPackageJson
     name="my-serenity-js-webdriverio-project"
     scripts={{
-        "serenity": "failsafe serenity:clean wdio [...] serenity:report",
-        "serenity:clean": "rimraf target",
-        "wdio": "wdio run ./wdio.conf.ts",
-        "serenity:report": "serenity-bdd run --features='./test/specs'"
+        "test": "wdio run ./wdio.conf.ts"
     }}
     devDependencies={[
         "@serenity-js/assertions",
         "@serenity-js/console-reporter",
         "@serenity-js/core",
+        "@serenity-js/html-reporter",
         "@serenity-js/mocha",
-        "@serenity-js/serenity-bdd",
         "@serenity-js/web",
         "@serenity-js/webdriverio",
         [ "@wdio/cli", "^9.0.0" ],
         [ "@wdio/local-runner", "^9.0.0" ],
-        [ "npm-failsafe", "^1.4.0" ],
-        [ "rimraf", "^6.0.0" ],
         [ "typescript", "^5.7.0" ],
         [ "webdriverio", "^9.0.0" ]
     ]}
@@ -252,10 +245,7 @@ export const config: WebdriverIOConfig = {
         runner: 'mocha',
         crew: [
             '@serenity-js/console-reporter',
-            [ '@serenity-js/serenity-bdd', { specDirectory: './test/specs' } ],
-            [ '@serenity-js/core:ArtifactArchiver', {
-                outputDirectory: './target/site/serenity'
-            } ],
+            [ '@serenity-js/html-reporter', { specDirectory: './test/specs' } ],
         ],
     },
     specs: [ './test/specs/**/*.spec.ts' ],
@@ -452,7 +442,7 @@ Yes. Screenplay Tasks import from `@serenity-js/web` and `@serenity-js/core` —
 
 ### Do I need Java?
 
-Yes, for the Serenity BDD HTML reports (Java 11+). If you'd rather stay Java-free, use the [console reporter](/handbook/reporting/console-reporter/) alone.
+Not if you use the [Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/) — it produces rich reports with trend tracking and flaky test detection using pure Node.js. Java is only needed for the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/).
 
 :::tip Something not working?
 Check the [Troubleshooting guide](/handbook/troubleshooting/) for solutions to common issues with reports, screenshots, and configuration.

--- a/src/docs/handbook/index.mdx
+++ b/src/docs/handbook/index.mdx
@@ -80,9 +80,11 @@ Serenity/JS revolutionises how teams approach test automation:
 
 ### Insightful reporting
 
-- Generate [**world-class test reports** and **living documentation**](/handbook/reporting/) that connect test outcomes to business requirements.
+- Generate [**world-class test reports**](/handbook/reporting/) with the [Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/) — a self-contained report with trend history across CI runs, flaky test detection, error clustering, and an interactive dashboard. No Java required.
 
-- Provide stakeholders with **clear, actionable insights** into your system's performance, stability, and release readiness.
+- **Track quality over time**: see how pass rate, consistency, and duration evolve across builds. Spot regressions immediately, identify degraded and recovered tests, and share deep-linked evidence with your team.
+
+- Provide stakeholders with **clear, actionable insights** into your system's stability, consistency, and release readiness — whether they're developers diagnosing a failure, QA engineers tracking flakiness, or product owners asking "can we ship?"
 
 
 ## Get started fast 🚀


### PR DESCRIPTION
Replace @serenity-js/serenity-bdd with @serenity-js/html-reporter across all getting-started guides (Playwright, WebdriverIO, Cucumber) and the 'Why Serenity/JS' comparison page.

Key changes:
- Remove Java prerequisite
- Remove rimraf, npm-failsafe dependencies
- Simplify package.json scripts (no clean/failsafe/report steps)
- Replace serenity-bdd crew config with html-reporter
- Update screenshots to HTML Reporter dashboard
- Update FAQ 'Do I need Java?' answers
- Update handbook index 'Insightful reporting' section