### PR TITLE
docs: update test-runner handbook pages to recommend HTML Reporter

### DIFF
--- a/src/docs/handbook/test-runners/cucumber.mdx
+++ b/src/docs/handbook/test-runners/cucumber.mdx
@@ -10,7 +10,7 @@ and a test runner capable of executing test scenarios
 written in [plain language](https://cucumber.io/docs/guides/overview/).
 
 **In this article, you will learn:**
-- How to use [Serenity/JS reporting services](/handbook/reporting/), including the [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter), even if your test scenarios don't follow the Screenplay Pattern yet
+- How to use [Serenity/JS reporting services](/handbook/reporting/), including the [HTML Reporter](/handbook/reporting/html-reporter/) and [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter), even if your test scenarios don't follow the Screenplay Pattern yet
 - How to implement Cucumber [step definitions](https://cucumber.io/docs/cucumber/step-definitions/?lang=javascript) using reusable [Serenity/JS Screenplay Pattern](/handbook/design/screenplay-pattern) APIs
 
 ## Examples and Project Templates
@@ -25,7 +25,8 @@ If you'd like to dive straight into the code,
 To use [Serenity/JS reporting services](/handbook/reporting/) in a Cucumber project, you need to:
 - attach the [`@serenity-js/cucumber`](/api/cucumber) test runner adapter to Cucumber
 - [configure Serenity/JS](/api/core/function/configure) to use the reporting services you want to use,
-such as the [`ConsoleReporter`](/handbook/reporting/console-reporter)
+such as the [`ConsoleReporter`](/handbook/reporting/console-reporter),
+[`HtmlReporter`](/handbook/reporting/html-reporter),
 or [`SerenityBDDReporter`](/handbook/reporting/serenity-bdd-reporter)
 
 :::tip Serenity/JS test runner adapters
@@ -105,8 +106,7 @@ BeforeAll(() => {
     configure({
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './features' }],
             // ... any other reporting services
         ],
     })
@@ -123,8 +123,7 @@ BeforeAll(() => {
     configure({
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './features' }],
             // ... any other reporting services
         ],
     })
@@ -218,8 +217,7 @@ BeforeAll(async () => {
         ),
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './features' }],
             // ... any other reporting services
         ],
     })

--- a/src/docs/handbook/test-runners/jasmine.mdx
+++ b/src/docs/handbook/test-runners/jasmine.mdx
@@ -10,7 +10,7 @@ If your project already uses Jasmine to run its unit tests,
 you can use the same runner for your acceptance tests too.
 
 **In this article, you will learn:**
-- How to use [Serenity/JS reporting services](/handbook/reporting/), including the [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter), even if your test scenarios don't follow the Screenplay Pattern yet
+- How to use [Serenity/JS reporting services](/handbook/reporting/), including the [HTML Reporter](/handbook/reporting/html-reporter/) and [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter), even if your test scenarios don't follow the Screenplay Pattern yet
 - How to implement Jasmine test scenarios using reusable [Serenity/JS Screenplay Pattern](/handbook/design/screenplay-pattern) APIs
 
 ## Examples and Project Templates
@@ -24,7 +24,8 @@ If you'd like to dive straight into the code, [Serenity/JS GitHub repository](ht
 To use [Serenity/JS reporting services](/handbook/reporting/) in a Jasmine project, you need to:
 - attach the [`@serenity-js/jasmine`](/api/jasmine) test runner adapter to Jasmine
 - [configure Serenity/JS](/api/core/function/configure) to use the reporting services you want to use,
-such as the [`ConsoleReporter`](/handbook/reporting/console-reporter)
+such as the [`ConsoleReporter`](/handbook/reporting/console-reporter),
+[`HtmlReporter`](/handbook/reporting/html-reporter),
 or [`SerenityBDDReporter`](/handbook/reporting/serenity-bdd-reporter)
 
 :::tip Serenity/JS test runner adapters
@@ -105,8 +106,7 @@ beforeAll(async () => {
     configure({
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './spec' }],
             // ... any other reporting services
         ],
     })
@@ -121,8 +121,7 @@ beforeAll(async () => {
     configure({
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './spec' }],
             // ... any other reporting services
         ],
     })
@@ -267,8 +266,7 @@ beforeAll(async () => {
         ),
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './spec' }],
             // ... any other reporting services
         ],
     })

--- a/src/docs/handbook/test-runners/mocha.mdx
+++ b/src/docs/handbook/test-runners/mocha.mdx
@@ -9,7 +9,7 @@ such as [automatic retry of failed tests](/api/mocha-adapter/interface/MochaConf
 If your project already uses Mocha to run its unit tests, you can use the same runner for your acceptance tests too.
 
 **In this article, you will learn:**
-- how to use [Serenity/JS reporting services](/handbook/reporting/), including the [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter), even if your test scenarios don't follow the Screenplay Pattern yet
+- how to use [Serenity/JS reporting services](/handbook/reporting/), including the [HTML Reporter](/handbook/reporting/html-reporter/) and [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter), even if your test scenarios don't follow the Screenplay Pattern yet
 - how to implement Mocha test scenarios using reusable [Serenity/JS Screenplay Pattern](/handbook/design/screenplay-pattern) APIs
 
 ## Examples and Project Templates
@@ -23,7 +23,8 @@ If you'd like to dive straight into the code, [Serenity/JS GitHub repository](ht
 To use [Serenity/JS reporting services](/handbook/reporting/) in a Mocha project, you need to:
 - attach the [`@serenity-js/mocha`](/api/mocha) test runner adapter to Mocha
 - [configure Serenity/JS](/api/core/function/configure) to use the reporting services you want to use,
-such as the [`ConsoleReporter`](/handbook/reporting/console-reporter)
+such as the [`ConsoleReporter`](/handbook/reporting/console-reporter),
+[`HtmlReporter`](/handbook/reporting/html-reporter),
 or [`SerenityBDDReporter`](/handbook/reporting/serenity-bdd-reporter)
 
 :::tip Serenity/JS test runner adapters
@@ -104,8 +105,7 @@ beforeAll(async () => {
     configure({
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './spec' }],
             // ... any other reporting services
         ],
     })
@@ -120,8 +120,7 @@ beforeAll(async () => {
     configure({
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './spec' }],
             // ... any other reporting services
         ],
     })
@@ -240,8 +239,7 @@ beforeAll(async () => {
         ),
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './spec' }],
             // ... any other reporting services
         ],
     })

--- a/src/docs/handbook/test-runners/playwright-test/configuration.mdx
+++ b/src/docs/handbook/test-runners/playwright-test/configuration.mdx
@@ -19,16 +19,15 @@ import { defineConfig, devices } from '@playwright/test'
 import type { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test'
 
 export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
+    testDir: './spec',
+
     reporter: [
         // Serenity/JS reporting services
         [ '@serenity-js/playwright-test', {
             crew: [
                 '@serenity-js/console-reporter',
-                [ '@serenity-js/serenity-bdd', {
+                [ '@serenity-js/html-reporter', {
                   specDirectory: './spec'
-                } ],
-                [ '@serenity-js/core:ArtifactArchiver', {
-                  outputDirectory: './target/site/serenity'
                 } ],
             ]
         }],
@@ -43,14 +42,16 @@ export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
 
 This configuration enables the [`@serenity-js/playwright-test`](/api/playwright-test/) test runner adapter, which in turn configures the ["stage crew"](/handbook/architecture/#serenityjs-reporting-services) of Serenity/JS reporting services:
 - [Console reporter](/handbook/reporting/console-reporter/) - Displays test results in the terminal.
-- [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter/) - Produces `json` reports to be ingested by the Serenity BDD CLI and produce the living documentation.
-- [Artifact Archiver](/handbook/reporting/artifact-archiver/) - Stores the `json` reports and screenshots captured by the Photographer to disk.
+- [HTML Reporter](/handbook/reporting/html-reporter/) - Produces a self-contained HTML report with trend history, flaky test detection, and an interactive dashboard.
 
 Note that the above configuration assumes the following directory structure of your project:
-- `./spec` - stores your test scenarios and is the top-most directory of your [requirements hierarchy](/handbook/reporting/serenity-bdd-reporter/#the-requirements-hierarchy).
-- `./target/site/serenity` - stores any test report artifacts, like the `.json` files and screenshots.
+- `./spec` - stores your test scenarios and is the top-most directory of your [requirements hierarchy](/handbook/reporting/html-reporter/#the-requirements-hierarchy).
 
-If you'd like to use different locations for your tests or the test reports, adjust the `specDirectory` and `outputDirectory` settings accordingly.
+If you'd like to use a different location for your tests, adjust the `specDirectory` setting accordingly.
+
+:::tip Using Serenity BDD Reporter instead?
+If you prefer Serenity BDD's multi-page report format, see the [Serenity BDD Reporter configuration](/handbook/reporting/serenity-bdd-reporter/#configuring-playwright-test).
+:::
 
 ## Enabling automatic screenshots
 

--- a/src/docs/handbook/test-runners/playwright-test/reporting.mdx
+++ b/src/docs/handbook/test-runners/playwright-test/reporting.mdx
@@ -4,56 +4,74 @@ sidebar_position: 7
 
 # Reporting
 
-Serenity/JS provides comprehensive reporting capabilities and integrates with both the [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter/) and the native Playwright Test reporting tools.
-The framework supports:
-- **Playwright Test HTML Reports** - Enhanced with Screenplay Pattern activity details and automatic screenshots.
-- **Playwright Test UI Mode** - Real-time test execution with Screenplay Pattern integration.
-- **Playwright Trace Viewer** - Detailed test execution traces, including Screenplay Pattern activities.
-- **Serenity BDD Reports** - Rich, business-focused living documentation of your system.
+Serenity/JS offers two reporting options for Playwright Test projects, and integrates with native Playwright reporting tools:
 
-Serenity/JS supports both classic Playwright Test scenarios and those that follow the [Screenplay Pattern](/handbook/design/screenplay-pattern/),
-allowing you to migrate to Screenplay gradually if you wish, or mix and match the two implementations within the same codebase.
+- **[Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/)** — self-contained report with trend history, flaky test detection, error clustering, and an interactive dashboard. No Java required.
+- **[Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/)** — multi-page HTML reports with narrative documentation. Requires Java.
+- **Playwright Test HTML Reports** — enhanced with Screenplay Pattern activity details and automatic screenshots.
+- **Playwright Test UI Mode** — real-time test execution with Screenplay Pattern integration.
+- **Playwright Trace Viewer** — detailed execution traces, including Screenplay Pattern activities.
 
-:::tip Reference Implementation
-Explore the [Serenity/JS + Playwright Test project template](https://github.com/serenity-js/serenity-js-playwright-test-template) to see these reports in action:
-- [Serenity BDD report](https://serenity-js.github.io/serenity-js-playwright-test-template/serenity/)
-- [Playwright Test report](https://serenity-js.github.io/serenity-js-playwright-test-template/playwright/)
-:::
+All reporters work with both classic Playwright Test scenarios and those that follow the [Screenplay Pattern](/handbook/design/screenplay-pattern/).
+
+---
+
+## Serenity/JS HTML Reporter
+
+The [HTML Reporter](/handbook/reporting/html-reporter/) is the recommended reporting option for most teams. It produces a self-contained report automatically at the end of each test run — no separate generation step, no Java, no additional dependencies.
+
+```ts title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+import type { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test';
+
+export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
+    testDir: './spec',
+
+    reporter: [
+        ['line'],
+        ['@serenity-js/playwright-test', {
+            crew: [
+                '@serenity-js/console-reporter',
+                ['@serenity-js/html-reporter', {
+                    specDirectory: './spec',   // same as testDir — enables the Capabilities view
+                }],
+            ]
+        }],
+
+        // Optional: keep the built-in Playwright HTML reporter for low-level debugging
+        ['html', { open: 'never' }],
+    ],
+});
+```
+
+After running `npx playwright test`, open `reports/serenity-js/index.html` in your browser, or serve it locally:
+
+```sh
+npx @serenity-js/html-reporter serve --open
+```
+
+<Figure
+    caption='Serenity/JS HTML Report — Dashboard with trend chart and KPI cards'
+    img={require('@site/static/images/reporting/html-reporter-dashboard.png')}
+    externalLink={'https://serenity-js.github.io/serenity-js/'}
+/>
+
+→ Learn more: [HTML Reporter guide](/handbook/reporting/html-reporter/) | [CI integration](/handbook/reporting/html-reporter/#ci-integration)
+
+---
 
 ## Playwright HTML reports
 
 Serenity/JS **automatically enhances** the built-in [Playwright HTML reports](https://playwright.dev/docs/test-reporters#html-reporter)
-with information gathered from your [Screenplay Pattern](/handbook/design/screenplay-pattern) activities.
+with information gathered from your test activities. When you use the [Screenplay Pattern APIs](/handbook/test-runners/playwright-test/writing-tests/#using-the-screenplay-pattern-apis), the reports show additional detail — named steps, activity trees, and timing breakdowns.
 
-To enable integration with the Playwright HTML reporter, you need to:
-1. Use the [Screenplay Pattern APIs](/handbook/test-runners/playwright-test/writing-tests/#using-the-screenplay-pattern-apis) in your Playwright Test scenarios.
-2. Configure the [Playwright HTML reporter](https://playwright.dev/docs/test-reporters#html-reporter) in your `playwright.config.ts` file.
+To enable it, add the Playwright HTML reporter alongside the Serenity/JS reporter:
 
 ```ts title="playwright.config.ts"
-import { defineConfig, devices } from '@playwright/test'
-import type { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test'
-
-export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
-    reporter: [
-        // Enable Serenity/JS reporting services
-        [ '@serenity-js/playwright-test', {
-            crew: [
-                '@serenity-js/console-reporter',
-                [ '@serenity-js/serenity-bdd', {
-                  specDirectory: './spec'
-                } ],
-                [ '@serenity-js/core:ArtifactArchiver', {
-                  outputDirectory: './target/site/serenity'
-                } ],
-            ]
-        }],
-
-        // Enable Playwright Test HTML reporter
-        [ 'html', { open: 'never' } ],
-    ],
-
-    // Other Playwright Test configuration options
-})
+reporter: [
+    ['@serenity-js/playwright-test', { /* ... */ }],
+    ['html', { open: 'never' }],
+],
 ```
 
 <Figure
@@ -86,7 +104,7 @@ To use this feature, you need to:
 2. Enable tracing in your `playwright.config.ts` file.
 
 ```ts title="playwright.config.ts"
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig } from '@playwright/test'
 import type { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test'
 
 export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
@@ -102,15 +120,14 @@ export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
     img={require('@site/static/images/test-runners/playwright-test/serenity-js-playwright-test-trace-viewer.png')}
 />
 
-## Serenity BDD Reports
+---
 
-[Serenity reports and living documentation](/handbook/reporting/serenity-bdd-reporter) are a powerful feature enabled by Serenity BDD.
-They aim not only to **report test results**, but also to document **how features are tested**, and **what your application does**.
+## Serenity BDD Reporter
+
+If your team already uses Serenity BDD or prefers its multi-page report format, you can use the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/) instead of (or alongside) the HTML Reporter.
 
 Serenity BDD reports are generated by the [Serenity BDD CLI](https://github.com/serenity-bdd/serenity-core/tree/main/serenity-cli),
 a Java program that ships with the [`@serenity-js/serenity-bdd`](/api/serenity-bdd/) module.
-These reports are based on the `json` reports produced by the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/),
-as well as screenshots captured by the [Photographer](/handbook/reporting/photographer/).
 
 <Figure
     caption='Example Serenity BDD report'
@@ -118,27 +135,26 @@ as well as screenshots captured by the [Photographer](/handbook/reporting/photog
     img={require('@site/static/images/reporting/serenity-bdd-reporter.png')}
 />
 
-To generate Serenity BDD HTML reports and living documentation, your test suite must:
-1. Use [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter/) and [`ArtifactArchiver`](/api/core/class/ArtifactArchiver/) as per the [configuration instructions](/handbook/test-runners/playwright-test/configuration/#integrating-serenityjs-reporting).
-2. Invoke the `serenity-bdd run` command when the test run has finished to generate the Serenity BDD report.
+To generate Serenity BDD reports, configure your crew as follows:
 
-All [Serenity/JS Project Templates](/getting-started/project-templates/) follow the same recommended pattern to generate Serenity BDD reports.
-This approach relies on:
-- NPM scripts to invoke the command-line tools, such as Playwright Test or the Serenity BDD CLI.
-- [`npm-failsafe`](https://www.npmjs.com/package/npm-failsafe) to execute a sequence of NPM scripts.
-- [`rimraf`](https://www.npmjs.com/package/rimraf) to remove any test reports left over from the previous run.
+```ts title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+import type { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test';
 
-You can install these additional recommended modules as follows:
-
-```sh npm2yarn
-npm install --save-dev npm-failsafe rimraf
+export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
+    reporter: [
+        ['@serenity-js/playwright-test', {
+            crew: [
+                '@serenity-js/console-reporter',
+                ['@serenity-js/serenity-bdd', { specDirectory: './spec' }],
+                ['@serenity-js/core:ArtifactArchiver', { outputDirectory: './target/site/serenity' }],
+            ]
+        }],
+    ],
+});
 ```
 
-Next, add the following convenience scripts to your `package.json` file:
-- `clean` - removes any test reports left over from the previous test run.
-- `test` - uses `npm-failsafe` to execute multiple NPM scripts and generate test reports.
-- `test:execute` - an example alias for `playwright test`. You can extend it to include any necessary command-line arguments.
-- `test:report` - an alias for `serenity-bdd run`. You can configure it with alternative `json` report locations (`--source`) and HTML report destinations (`--destination`). Run `npx serenity-bdd run --help` to see the available options.
+Then add the following scripts to your `package.json`:
 
 ```json title="package.json"
 {
@@ -146,59 +162,31 @@ Next, add the following convenience scripts to your `package.json` file:
     "clean": "rimraf target",
     "test": "failsafe clean test:execute test:report",
     "test:execute": "playwright test",
-    "test:report": "serenity-bdd run --source ./target/site/serenity --destination ./target/site/serenity",
+    "test:report": "serenity-bdd run --source ./target/site/serenity --destination ./target/site/serenity"
   }
 }
 ```
 
-To learn more about the `SerenityBDDReporter`, see:
-- [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter/) API documentation and configuration examples.
-- [Serenity/JS + Playwright Test project template](https://github.com/serenity-js/serenity-js-playwright-test-template) on GitHub
-- [Serenity/JS examples](https://github.com/serenity-js/serenity-js/tree/main/examples) on GitHub
+This requires additional dependencies:
 
-### Chaining NPM scripts
-
-A common advanced usage pattern for systems with multiple test suites is to execute each test suite separately on CI across multiple [pipeline stages](/handbook/integration/),
-while running them sequentially in a local environment. In both cases, a single Serenity BDD report is generated at the end.
-This pattern is particularly useful for systems with multiple [Playwright Test projects](https://playwright.dev/docs/test-projects) or those that use both the [Playwright Component Test runner](/getting-started/project-templates/#web-component-testing) and
-the [Playwright Test runner](/getting-started/project-templates/#playwright).
-
-<figure>
-```mermaid
-graph LR
-    A["test:ct"] --> B
-    B["build"] --> C
-    C["test:e2e"] --> D["test:report"]
-```
-<figcaption>Example CI pipeline running tests and build steps across multiple pipeline stages</figcaption>
-</figure>
-
-To implement this pattern, define an NPM script for each project and the report generation step, then use `npm-failsafe` to chain the NPM scripts for local execution.
-
-
-```json title="package.json"
-{
-  "scripts": {
-    "build": "esbuild src/app.tsx ...",
-    "test": "failsafe test:clean test:ct build test:e2e test:report",
-    "test:clean": "rimraf target",
-    "test:ct": "playwright test-ct --config playwright-ct.config.ts",
-    "test:e2e": "playwright test --config playwright.config.ts",
-    "test:report": "serenity-bdd run --source ./target/site/serenity --destination ./target/site/serenity",
-  }
-}
+```sh npm2yarn
+npm install --save-dev @serenity-js/serenity-bdd npm-failsafe rimraf
 ```
 
-:::tip Parameterized NPM scripts
-`npm-failsafe` enables additional advanced usage and configuration patterns, such as passing runtime
-parameters to your NPM scripts. See the [`npm-failsafe` documentation](https://github.com/jan-molak/npm-failsafe?tab=readme-ov-file#configuration) for examples.
+→ Learn more: [Serenity BDD Reporter guide](/handbook/reporting/serenity-bdd-reporter/) | [Migrating to the HTML Reporter](/handbook/reporting/html-reporter/#migrating-from-serenity-bdd-reporter)
+
+:::tip Use both reporters together
+You can run both the HTML Reporter and Serenity BDD Reporter simultaneously — they collect data independently and write to different directories. See [Running both reporters together](/handbook/reporting/html-reporter/#running-both-reporters-together).
 :::
+
+---
 
 ## What you learnt
 
-- Serenity/JS automatically enhances Playwright HTML reports, UI Mode, and Trace Viewer with Screenplay Pattern details.
-- Serenity BDD reports provide business-focused living documentation generated from JSON artifacts.
-- Use `npm-failsafe` to chain test execution and report generation scripts reliably.
+- The **Serenity/JS HTML Reporter** is the simplest way to get rich reports — no Java, no extra scripts, automatic generation.
+- Serenity/JS automatically enhances **Playwright HTML reports, UI Mode, and Trace Viewer** with Screenplay Pattern details.
+- **Serenity BDD reports** are available for teams that need Java-based living documentation.
+- Both Serenity/JS reporters work alongside native Playwright reporting tools.
 
 ## Next step
 

--- a/src/docs/handbook/test-runners/protractor.mdx
+++ b/src/docs/handbook/test-runners/protractor.mdx
@@ -50,7 +50,11 @@ will also help you **future-proof your codebase** and make it **agnostic** of th
 - Start using the **Screenplay Pattern**.
 - Replace Protractor with **WebdriverIO** while keeping your tests working!
 
-![Serenity BDD Report Example](/images/reporting/serenity-bdd-reporter.png)
+<Figure
+    caption='Serenity/JS HTML Report — interactive dashboard with trend history, flaky test detection, and execution evidence'
+    img={require('@site/static/images/reporting/html-reporter-dashboard.png')}
+    externalLink={'https://serenity-js.github.io/serenity-js/'}
+/>
 
 ## Quick start 🚀
 
@@ -77,7 +81,7 @@ Then, create a new Protractor project or add Serenity/JS integration and reporti
 To add Serenity/JS to a Protractor project, install the following modules:
 
 ```sh npm2yarn
-npm install --save-dev @serenity-js/core @serenity-js/console-reporter @serenity-js/protractor @serenity-js/rest @serenity-js/web @serenity-js/serenity-bdd
+npm install --save-dev @serenity-js/core @serenity-js/console-reporter @serenity-js/protractor @serenity-js/rest @serenity-js/web @serenity-js/html-reporter
 ```
 
 This command installs:
@@ -86,7 +90,7 @@ This command installs:
 - [`@serenity-js/protractor`](/api/protractor)
 - [`@serenity-js/rest`](/api/rest)
 - [`@serenity-js/web`](/api/web)
-- [`@serenity-js/serenity-bdd`](/api/serenity-bdd)
+- [`@serenity-js/html-reporter`](/api/html-reporter)
 
 Protractor offers a test runner that uses Jasmine, Mocha, or Cucumber to run your test scenarios.
 Since the task of running the scenarios is delegated to another tool,
@@ -129,14 +133,10 @@ exports.config = {
             // Optional, print test execution results to standard output
             '@serenity-js/console-reporter',
 
-            // Optional, produce Serenity BDD reports
-            // and living documentation (HTML)
-            [ '@serenity-js/serenity-bdd', {
+            // Optional, produce Serenity/JS HTML reports
+            // with trend history and flaky test detection
+            [ '@serenity-js/html-reporter', {
                 specDirectory: './features'
-            } ],
-
-            [ '@serenity-js/core:ArtifactArchiver', {
-                outputDirectory: 'target/site/serenity'
             } ],
 
             // Optional, automatically capture screenshots
@@ -183,14 +183,10 @@ exports.config = {
             // Optional, print test execution results to standard output
             '@serenity-js/console-reporter',
 
-            // Optional, produce Serenity BDD reports
-            // and living documentation (HTML)
-            [ '@serenity-js/serenity-bdd', {
+            // Optional, produce Serenity/JS HTML reports
+            // with trend history and flaky test detection
+            [ '@serenity-js/html-reporter', {
                 specDirectory: './spec'
-            } ],
-
-            [ '@serenity-js/core:ArtifactArchiver', {
-                outputDirectory: 'target/site/serenity'
             } ],
 
             // Optional, automatically capture screenshots
@@ -231,14 +227,10 @@ exports.config = {
             // Optional, print test execution results to standard output
             '@serenity-js/console-reporter',
 
-            // Optional, produce Serenity BDD reports
-            // and living documentation (HTML)
-            [ '@serenity-js/serenity-bdd', {
+            // Optional, produce Serenity/JS HTML reports
+            // with trend history and flaky test detection
+            [ '@serenity-js/html-reporter', {
                 specDirectory: './spec'
-            } ],
-
-            [ '@serenity-js/core:ArtifactArchiver', {
-                outputDirectory: 'target/site/serenity'
             } ],
 
             // Optional, automatically capture screenshots
@@ -260,15 +252,13 @@ exports.config = {
 
 This configuration enables the [`@serenity-js/protractor`](/api/protractor/) test runner adapter, which in turn configures the ["stage crew"](/handbook/architecture/#serenityjs-reporting-services) of Serenity/JS reporting services:
 - [Console reporter](/handbook/reporting/console-reporter/) - Displays test results in the terminal.
-- [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter/) - Produces `json` reports to be ingested by the Serenity BDD CLI and produce the living documentation.
+- [HTML Reporter](/handbook/reporting/html-reporter/) - Produces a self-contained HTML report with trend history, flaky test detection, and an interactive dashboard.
 - [Photographer](/handbook/reporting/photographer/) - Automatically captures screenshots of the browser upon interactions or assertion failures when configured with `TakePhotosOfInteractions` or `TakePhotosOfFailures`, respectively.
-- [Artifact Archiver](/handbook/reporting/artifact-archiver/) - Stores the `json` reports and screenshots captured by the Photographer to disk.
 
 Note that the above configuration assumes the following directory structure of your project:
-- `./spec` or `./features` - stores your test scenarios and is the top-most directory of your [requirements hierarchy](/handbook/reporting/serenity-bdd-reporter/#the-requirements-hierarchy).
-- `./target/site/serenity` - stores any test report artifacts, like the `.json` files and screenshots.
+- `./spec` or `./features` - stores your test scenarios and is the top-most directory of your [requirements hierarchy](/handbook/reporting/html-reporter/#the-requirements-hierarchy).
 
-If you'd like to use different locations for your tests or the test reports, adjust the `specDirectory` and `outputDirectory` settings accordingly.
+If you'd like to use a different location for your tests, adjust the `specDirectory` setting accordingly.
 
 Learn more about the configuration options for your test runner:
 | Test Runner | Configuration Options | Complete `protractor.conf.js` |
@@ -409,8 +399,7 @@ exports.config = {
         actors: new MyActors(),
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './spec' }],
             [ '@serenity-js/web:Photographer', { strategy: 'TakePhotosOfFailures' } ],
         ]
     },
@@ -421,48 +410,64 @@ exports.config = {
 
 ## Reporting
 
-Serenity/JS provides comprehensive reporting capabilities and integrates with the [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter/).
+Serenity/JS offers two reporting options for Protractor projects:
 
-:::tip Reference Implementation
-Explore the [Serenity/JS + Protractor project templates](/getting-started/project-templates/#protractor) to see the reporting capabilities in action.
-:::
+- **[Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/)** — self-contained report with trend history, flaky test detection, and an interactive dashboard. No Java required.
+- **[Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/)** — multi-page HTML reports with narrative documentation. Requires Java.
 
-### Serenity BDD Reports
+### Serenity/JS HTML Reporter
 
-[Serenity reports and living documentation](/handbook/reporting/serenity-bdd-reporter) are a powerful feature enabled by Serenity BDD.
-They aim not only to **report test results**, but also to document **how features are tested**, and **what your application does**.
+The [HTML Reporter](/handbook/reporting/html-reporter/) is the recommended option. It produces a report automatically at the end of each test run.
 
-Serenity BDD reports are generated by the [Serenity BDD CLI](https://github.com/serenity-bdd/serenity-core/tree/main/serenity-cli),
-a Java program that ships with the [`@serenity-js/serenity-bdd`](/api/serenity-bdd/) module.
-These reports are based on the `json` reports produced by the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/),
-as well as screenshots captured by the [Photographer](/handbook/reporting/photographer/).
+```js title="protractor.conf.js"
+exports.config = {
+    framework: 'custom',
+    frameworkPath: require.resolve('@serenity-js/protractor/adapter'),
+
+    serenity: {
+        crew: [
+            '@serenity-js/console-reporter',
+            ['@serenity-js/html-reporter', { specDirectory: './spec' }],
+            ['@serenity-js/web:Photographer', { strategy: 'TakePhotosOfFailures' }],
+        ]
+    },
+
+    // ... other configuration
+};
+```
+
+After running `npm test`, open `reports/serenity-js/index.html` in your browser, or serve it locally:
+
+```sh
+npx @serenity-js/html-reporter serve --open
+```
+
+→ Learn more: [HTML Reporter guide](/handbook/reporting/html-reporter/) | [CI integration](/handbook/reporting/html-reporter/#ci-integration)
+
+### Serenity BDD Reporter
+
+If your team already uses Serenity BDD or prefers its multi-page report format, you can use the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/) instead of (or alongside) the HTML Reporter.
 
 <Figure
     caption='Example Serenity BDD report'
     img={require('@site/static/images/reporting/serenity-bdd-reporter.png')}
 />
 
-To generate Serenity BDD HTML reports and living documentation, your test suite must:
-1. Use [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter/) and [`ArtifactArchiver`](/api/core/class/ArtifactArchiver/) as per the [configuration instructions](#integrating-serenityjs-reporting).
-2. Invoke the `serenity-bdd run` command when the test run has finished to generate the Serenity BDD report.
+```js title="protractor.conf.js"
+exports.config = {
+    framework: 'custom',
+    frameworkPath: require.resolve('@serenity-js/protractor/adapter'),
 
-All [Serenity/JS Project Templates](/getting-started/project-templates/) follow the same recommended pattern to generate Serenity BDD reports.
-This approach relies on:
-- NPM scripts to invoke the command-line tools, such as Playwright Test or the Serenity BDD CLI.
-- [`npm-failsafe`](https://www.npmjs.com/package/npm-failsafe) to execute a sequence of NPM scripts.
-- [`rimraf`](https://www.npmjs.com/package/rimraf) to remove any test reports left over from the previous run.
-
-You can install these additional recommended modules as follows:
-
-```sh npm2yarn
-npm install --save-dev npm-failsafe rimraf
+    serenity: {
+        crew: [
+            '@serenity-js/console-reporter',
+            '@serenity-js/serenity-bdd',
+            ['@serenity-js/core:ArtifactArchiver', { outputDirectory: './target/site/serenity' }],
+            ['@serenity-js/web:Photographer', { strategy: 'TakePhotosOfFailures' }],
+        ]
+    },
+};
 ```
-
-Next, add the following convenience scripts to your `package.json` file:
-- `clean` - removes any test reports left over from the previous test run.
-- `test` - uses `npm-failsafe` to execute multiple NPM scripts and generate test reports.
-- `test:execute` - an example alias for `protractor`. You can extend it to include any necessary command-line arguments.
-- `test:report` - an alias for `serenity-bdd run`. You can configure it with alternative `json` report locations (`--source`) and HTML report destinations (`--destination`). Run `npx serenity-bdd run --help` to see the available options.
 
 ```json title="package.json"
 {
@@ -470,15 +475,18 @@ Next, add the following convenience scripts to your `package.json` file:
     "clean": "rimraf target",
     "test": "failsafe clean test:execute test:report",
     "test:execute": "protractor ./protractor.conf.js",
-    "test:report": "serenity-bdd run --source ./target/site/serenity --destination ./target/site/serenity",
+    "test:report": "serenity-bdd run --source ./target/site/serenity --destination ./target/site/serenity"
   }
 }
 ```
 
-To learn more about the `SerenityBDDReporter`, see:
-- [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter/) API documentation and configuration examples.
-- [Serenity/JS Protractor project templates](/getting-started/project-templates/#protractor)
-- [Serenity/JS examples](https://github.com/serenity-js/serenity-js/tree/main/examples) on GitHub
+This requires additional dependencies:
+
+```sh npm2yarn
+npm install --save-dev @serenity-js/serenity-bdd npm-failsafe rimraf
+```
+
+→ Learn more: [Serenity BDD Reporter guide](/handbook/reporting/serenity-bdd-reporter/) | [Migrating to the HTML Reporter](/handbook/reporting/html-reporter/#migrating-from-serenity-bdd-reporter)
 
 ## Migrating from Protractor to Serenity/JS
 

--- a/src/docs/handbook/test-runners/webdriverio.mdx
+++ b/src/docs/handbook/test-runners/webdriverio.mdx
@@ -31,7 +31,11 @@ helping both technical teams and business stakeholders understand the quality of
 - Add Serenity/JS integration and reporting modules to new or existing WebdriverIO projects.
 - Implement WebdriverIO Test scenarios using Serenity/JS Screenplay Pattern APIs and the [Serenity/JS WebdriverIO module](/api/webdriverio).
 
-![Serenity BDD Report Example](/images/reporting/serenity-bdd-reporter.png)
+<Figure
+    caption='Serenity/JS HTML Report — interactive dashboard with trend history, flaky test detection, and execution evidence'
+    img={require('@site/static/images/reporting/html-reporter-dashboard.png')}
+    externalLink={'https://serenity-js.github.io/serenity-js/'}
+/>
 
 ## Quick start 🚀
 
@@ -198,15 +202,12 @@ export const config: WebdriverIOConfig = {
             // Optional, print test execution results to standard output
             '@serenity-js/console-reporter',
 
-            // Optional, produce Serenity BDD reports
-            // and living documentation (HTML)
-            [ '@serenity-js/serenity-bdd', {
+            // Optional, produce Serenity/JS HTML reports
+            // with trend history and flaky test detection
+            [ '@serenity-js/html-reporter', {
               specDirectory: './features'
             } ],
 
-            [ '@serenity-js/core:ArtifactArchiver', {
-              outputDirectory: './target/site/serenity'
-            } ],
             // Optional, automatically capture screenshots
             // upon interaction failure
             [ '@serenity-js/web:Photographer', {
@@ -248,15 +249,12 @@ export const config: WebdriverIOConfig = {
             // Optional, print test execution results to standard output
             '@serenity-js/console-reporter',
 
-            // Optional, produce Serenity BDD reports
-            // and living documentation (HTML)
-            [ '@serenity-js/serenity-bdd', {
+            // Optional, produce Serenity/JS HTML reports
+            // with trend history and flaky test detection
+            [ '@serenity-js/html-reporter', {
               specDirectory: './test/specs'
             } ],
 
-            [ '@serenity-js/core:ArtifactArchiver', {
-              outputDirectory: './target/site/serenity'
-            } ],
             // Optional, automatically capture screenshots
             // upon interaction failure
             [ '@serenity-js/web:Photographer', {
@@ -291,15 +289,12 @@ export const config: WebdriverIOConfig = {
             // Optional, print test execution results to standard output
             '@serenity-js/console-reporter',
 
-            // Optional, produce Serenity BDD reports
-            // and living documentation (HTML)
-            [ '@serenity-js/serenity-bdd', {
+            // Optional, produce Serenity/JS HTML reports
+            // with trend history and flaky test detection
+            [ '@serenity-js/html-reporter', {
               specDirectory: './test/specs'
             } ],
 
-            [ '@serenity-js/core:ArtifactArchiver', {
-              outputDirectory: './target/site/serenity'
-            } ],
             // Optional, automatically capture screenshots
             // upon interaction failure
             [ '@serenity-js/web:Photographer', {
@@ -319,17 +314,15 @@ export const config: WebdriverIOConfig = {
 };
 ```
 
-This configuration enables the [`@serenity-js/protractor`](/api/protractor/) test runner adapter, which in turn configures the ["stage crew"](/handbook/architecture/#serenityjs-reporting-services) of Serenity/JS reporting services:
+This configuration enables the [`@serenity-js/webdriverio`](/api/webdriverio/) test runner adapter, which in turn configures the ["stage crew"](/handbook/architecture/#serenityjs-reporting-services) of Serenity/JS reporting services:
 - [Console reporter](/handbook/reporting/console-reporter/) - Displays test results in the terminal.
-- [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter/) - Produces `json` reports to be ingested by the Serenity BDD CLI and produce the living documentation.
+- [HTML Reporter](/handbook/reporting/html-reporter/) - Produces a self-contained HTML report with trend history, flaky test detection, and an interactive dashboard.
 - [Photographer](/handbook/reporting/photographer/) - Automatically captures screenshots of the browser upon interactions or assertion failures when configured with `TakePhotosOfInteractions` or `TakePhotosOfFailures`, respectively.
-- [Artifact Archiver](/handbook/reporting/artifact-archiver/) - Stores the `json` reports and screenshots captured by the Photographer to disk.
 
 Note that the above configuration assumes the following directory structure of your project:
-- `./test/specs` or `./features` - stores your test scenarios and is the top-most directory of your [requirements hierarchy](/handbook/reporting/serenity-bdd-reporter/#the-requirements-hierarchy).
-- `./target/site/serenity` - stores any test report artifacts, like the `.json` files and screenshots.
+- `./test/specs` or `./features` - stores your test scenarios and is the top-most directory of your [requirements hierarchy](/handbook/reporting/html-reporter/#the-requirements-hierarchy).
 
-If you'd like to use different locations for your tests or the test reports, adjust the `specDirectory` and `outputDirectory` settings accordingly.
+If you'd like to use a different location for your tests, adjust the `specDirectory` setting accordingly.
 
 Learn more about the configuration options for your test runner:
 | Test Runner | Configuration Options | Complete `wdio.conf.ts` |
@@ -491,8 +484,7 @@ export const config: WebdriverIOConfig = {
         actors: new MyActors('https://admin-api.example.org'),
         crew: [
             '@serenity-js/console-reporter',
-            '@serenity-js/serenity-bdd',
-            [ '@serenity-js/core:ArtifactArchiver', { outputDirectory: 'target/site/serenity' } ],
+            ['@serenity-js/html-reporter', { specDirectory: './test/specs' }],
         ],
     },
 }
@@ -501,75 +493,91 @@ export const config: WebdriverIOConfig = {
 
 ## Reporting
 
-Serenity/JS provides comprehensive reporting capabilities and integrates with the [Serenity BDD reporter](/handbook/reporting/serenity-bdd-reporter/).
+Serenity/JS offers two reporting options for WebdriverIO projects:
 
-:::tip Reference Implementation
-Explore the [Serenity/JS + WebdriverIO project templates](/getting-started/project-templates/#webdriverio) to see the reporting capabilities in action.
-:::
+- **[Serenity/JS HTML Reporter](/handbook/reporting/html-reporter/)** — self-contained report with trend history, flaky test detection, and an interactive dashboard. No Java required.
+- **[Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/)** — multi-page HTML reports with narrative documentation. Requires Java.
 
-### Serenity BDD Reports
+### Serenity/JS HTML Reporter
 
-[Serenity reports and living documentation](/handbook/reporting/serenity-bdd-reporter) are a powerful feature enabled by Serenity BDD.
-They aim not only to **report test results**, but also to document **how features are tested**, and **what your application does**.
+The [HTML Reporter](/handbook/reporting/html-reporter/) is the recommended option for most teams. It produces a report automatically at the end of each test run — no separate generation step needed.
+
+```ts title="wdio.conf.ts"
+import type { WebdriverIOConfig } from '@serenity-js/webdriverio';
+
+export const config: WebdriverIOConfig = {
+    framework: '@serenity-js/webdriverio',
+
+    serenity: {
+        runner: 'mocha',
+        crew: [
+            '@serenity-js/console-reporter',
+            ['@serenity-js/html-reporter', {
+                specDirectory: './test/specs',   // root of your specs directory
+            }],
+        ],
+    },
+
+    specs: ['./test/specs/**/*.spec.ts'],
+};
+```
+
+After running `npm test`, open `reports/serenity-js/index.html` in your browser, or serve it locally:
+
+```sh
+npx @serenity-js/html-reporter serve --open
+```
+
+<Figure
+    caption='Serenity/JS HTML Report — Dashboard with trend chart and KPI cards'
+    img={require('@site/static/images/reporting/html-reporter-dashboard.png')}
+    externalLink={'https://serenity-js.github.io/serenity-js/'}
+/>
+
+→ Learn more: [HTML Reporter guide](/handbook/reporting/html-reporter/) | [CI integration](/handbook/reporting/html-reporter/#ci-integration)
+
+### Serenity BDD Reporter
+
+If your team already uses Serenity BDD or prefers its multi-page report format, you can use the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/) instead of (or alongside) the HTML Reporter.
 
 Serenity BDD reports are generated by the [Serenity BDD CLI](https://github.com/serenity-bdd/serenity-core/tree/main/serenity-cli),
 a Java program that ships with the [`@serenity-js/serenity-bdd`](/api/serenity-bdd/) module.
-These reports are based on the `json` reports produced by the [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/),
-as well as screenshots captured by the [Photographer](/handbook/reporting/photographer/).
 
 <Figure
     caption='Example Serenity BDD report'
     img={require('@site/static/images/reporting/serenity-bdd-reporter.png')}
 />
 
-To generate Serenity BDD HTML reports and living documentation, your test suite must:
-1. Use [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter/) and [`ArtifactArchiver`](/api/core/class/ArtifactArchiver/) as per the [configuration instructions](#integrating-serenityjs-reporting).
-2. Invoke the `serenity-bdd run` command when the test run has finished to generate the Serenity BDD report.
+To generate Serenity BDD reports, configure your crew and scripts as follows:
 
-All [Serenity/JS Project Templates](/getting-started/project-templates/) follow the same recommended pattern to generate Serenity BDD reports.
-This approach relies on:
-- NPM scripts to invoke the command-line tools, such as Playwright Test or the Serenity BDD CLI.
-- [`npm-failsafe`](https://www.npmjs.com/package/npm-failsafe) to execute a sequence of NPM scripts.
-- [`rimraf`](https://www.npmjs.com/package/rimraf) to remove any test reports left over from the previous run.
-
-You can install these additional recommended modules as follows:
-
-```sh npm2yarn
-npm install --save-dev npm-failsafe rimraf
+```ts title="wdio.conf.ts"
+serenity: {
+    crew: [
+        '@serenity-js/console-reporter',
+        ['@serenity-js/serenity-bdd', { specDirectory: './test/specs' }],
+        ['@serenity-js/core:ArtifactArchiver', { outputDirectory: './target/site/serenity' }],
+    ],
+},
 ```
-
-Next, add the following convenience scripts to your `package.json` file:
-- `clean` - removes any test reports left over from the previous test run.
-- `test` - uses `npm-failsafe` to execute multiple NPM scripts and generate test reports.
-- `test:execute` - an example alias for `protractor`. You can extend it to include any necessary command-line arguments.
-- `test:report` - an alias for `serenity-bdd run`. You can configure it with alternative `json` report locations (`--source`) and HTML report destinations (`--destination`). Run `npx serenity-bdd run --help` to see the available options.
 
 ```json title="package.json"
 {
   "scripts": {
     "clean": "rimraf target",
-    "test": "failsafe clean test:execute test:report",
-    "test:execute": "protractor ./protractor.conf.js",
-    "test:report": "serenity-bdd run --source ./target/site/serenity --destination ./target/site/serenity",
+    "serenity": "failsafe clean wdio serenity:report",
+    "wdio": "wdio run ./wdio.conf.ts",
+    "serenity:report": "serenity-bdd run --source ./target/site/serenity --destination ./target/site/serenity"
   }
 }
 ```
 
-When your test run finishes, test results will be available in the `target/site/serenity` directory.
-To view them, open the `index.html` file in your preferred web browser.
+This requires additional dependencies:
 
-:::tip Using WebdriverIO CLI wizard
-To avoid naming conflicts with any existing `test` script, projects created using the [WebdriverIO CLI wizard](#initialising-a-webdriverio-project) come pre-configured with a `serenity` script that runs your tests and generates the reports:
-
-```sh
-npm run serenity
+```sh npm2yarn
+npm install --save-dev @serenity-js/serenity-bdd npm-failsafe rimraf
 ```
-:::
 
-To learn more about the `SerenityBDDReporter`, see:
-- [`SerenityBDDReporter`](/api/serenity-bdd/class/SerenityBDDReporter/) API documentation and configuration examples.
-- [Serenity/JS WebdriverIO project templates](/getting-started/project-templates/#webdriverio)
-- [Serenity/JS examples](https://github.com/serenity-js/serenity-js/tree/main/examples) on GitHub
+→ Learn more: [Serenity BDD Reporter guide](/handbook/reporting/serenity-bdd-reporter/) | [Migrating to the HTML Reporter](/handbook/reporting/html-reporter/#migrating-from-serenity-bdd-reporter)
 
 ## Upgrading to WebdriverIO 9
 
@@ -596,7 +604,7 @@ If you had them in your `package.json`, you should remove them.
 
 ### Updating TypeScript configuration
 
-Update `compilerOptions` configuration in your `tsconfig.json` to target `es2022`:
+Update `compilerOptions` configuration in your `tsconfig.json` to target at least `es2022`:
 
 ```diff title="tsconfig.json"
 {


### PR DESCRIPTION
- Playwright Test reporting page: rewrite to lead with HTML Reporter, move Serenity BDD to alternative section, remove chaining NPM scripts
- Playwright Test configuration page: update crew example to html-reporter
- WebdriverIO: rewrite reporting section with HTML Reporter primary
- WebdriverIO: update opening screenshot to HTML Reporter dashboard
- Cucumber: update config examples and intro to show html-reporter
- Mocha: update config examples and intro to show html-reporter
- Jasmine: update config examples and intro to show html-reporter
- Protractor: update opening screenshot to HTML Reporter dashboard