### PR TITLE
docs: add CI integration guides (GitHub Actions, GitLab CI, Jenkins)

### DIFF
--- a/src/docs/handbook/integration/github-actions.mdx
+++ b/src/docs/handbook/integration/github-actions.mdx
@@ -1,9 +1,393 @@
+---
+title: GitHub Actions
+---
+
+export const PlaywrightVersion = () => <SupportedIntegrationVersion name="playwright-core" format="exact" />;
+
 # GitHub Actions
 
-Serenity/JS integrates with [industry-standard test runners](/handbook/test-runners/), so that your test scenarios can be executed
-using your regular build tools, <abbr title="Continuous Integration and Delivery">CI/CD</abbr> pipelines, and <abbr title="Integrated Development Environments">IDEs</abbr>.
+Serenity/JS integrates with [GitHub Actions](https://github.com/features/actions) to run your acceptance tests in CI
+and publish interactive HTML reports with trend history, flaky test detection, and error clustering.
 
-In this article, I'll show you how to configure [GitHub Actions CI](https://github.com/features/actions),
-to run automated acceptance tests built using Serenity/JS, and publish test execution reports and living documentation.
+In this guide, you'll learn how to configure GitHub Actions workflows that:
+- Run Serenity/JS test scenarios using the official [Serenity/JS Docker image](/handbook/integration/docker/)
+- Publish the [HTML Reporter](/handbook/reporting/html-reporter/) output to GitHub Pages
+- Preserve execution history across builds for trend analysis
 
-<ArticleComingSoon />
+## Before you start
+
+Set up a working Serenity/JS test suite using one of the official [Serenity/JS Project Templates](/getting-started/project-templates/),
+or add Serenity/JS to your existing project by following the [Serenity/JS installation guide](/handbook/installation/).
+
+If you're new to Serenity/JS, [follow the tutorial](/handbook/tutorials/your-first-web-scenario) to learn more about the framework.
+
+## Running Serenity/JS on GitHub Actions
+
+GitHub Actions workflows run on [virtual machines](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners)
+or inside [containers](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontainer).
+
+To ensure a stable, reproducible testing environment, use the official
+[Serenity/JS Docker image](/handbook/integration/docker/) as a job container. It comes pre-configured with:
+- The latest Long-Term Support (LTS) version of Node.js
+- All Playwright browser engines, plus stable Chrome and Edge
+- OpenJDK Java Runtime Environment (for teams also using [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/))
+
+:::tip Why use a container?
+Running tests inside a container eliminates environment drift between local development and CI.
+Browser versions, system dependencies, and font rendering all stay consistent — reducing flaky failures
+caused by infrastructure differences rather than product bugs.
+:::
+
+## Single-module project
+
+A single-module project has one test suite that runs in a single CI job. This is the most common setup for small to medium projects.
+
+The [`HtmlReporter`](/handbook/reporting/html-reporter/) crew member handles both data collection and report generation automatically — no separate aggregation step is needed.
+
+### Basic workflow
+
+This workflow runs your tests and uploads the report as a build artifact:
+
+<DynamicCodeBlock title=".github/workflows/test.yml" lang="yaml">
+{`name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: serenity-report
+          path: reports/serenity-js/
+          retention-days: 14
+`}
+</DynamicCodeBlock>
+
+:::tip Always upload the report
+Use `if: always()` on the upload step so the report is available even when tests fail —
+that's exactly when you need it most.
+:::
+
+### Publishing to GitHub Pages
+
+To publish the report to GitHub Pages with trend history preserved across builds, add a deployment job
+that restores the previous report before generating the new one:
+
+<DynamicCodeBlock title=".github/workflows/test.yml" lang="yaml">
+{`name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Restore previous report (preserves trend history)
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: reports/serenity-js
+        continue-on-error: true
+
+      - name: Run tests
+        run: npm test
+
+      - name: Deploy report to GitHub Pages
+        if: always() && github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: reports/serenity-js
+          clean: true
+`}
+</DynamicCodeBlock>
+
+**How trend history works:**
+
+1. Before running tests, the workflow checks out the `gh-pages` branch into `reports/serenity-js/`. This restores the `test-runs/` directory containing data from previous builds.
+2. When tests run, the `HtmlReporter` writes new data to `reports/serenity-js/test-runs/<runId>/` and aggregates all available runs into the final report.
+3. After tests complete, the entire `reports/serenity-js/` directory — including the new run — is deployed back to `gh-pages`.
+
+Each build accumulates history. Use the [`maxHistory`](/handbook/reporting/html-reporter/#configuration-options) option to control how many runs are retained.
+
+:::note GitHub Pages setup
+Ensure GitHub Pages is enabled for your repository (Settings → Pages → Source: "Deploy from a branch", branch: `gh-pages`).
+The first run will create the `gh-pages` branch automatically.
+:::
+
+## Multi-module project
+
+A multi-module project runs tests across multiple parallel jobs — for example, testing separate applications,
+browser variants, or sharded test suites. Each job produces its own test data, and a final job aggregates
+everything into one report.
+
+### Example: admin-ui and customer-ui
+
+Consider a monorepo with two UI modules, each with its own test suite:
+
+```
+my-project/
+├── modules/
+│   ├── admin-ui/
+│   │   ├── spec/
+│   │   └── playwright.config.ts
+│   └── customer-ui/
+│       ├── spec/
+│       └── playwright.config.ts
+└── package.json
+```
+
+### Step 1: Configure each module to archive data only
+
+In each module's `playwright.config.ts`, use `TestRunArchiver` instead of the full `HtmlReporter`.
+This collects test data without generating the final report:
+
+```ts title="modules/admin-ui/playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+import type { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test';
+
+export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
+    testDir: './spec',
+
+    reporter: [
+        ['line'],
+        ['@serenity-js/playwright-test', {
+            crew: [
+                ['@serenity-js/html-reporter:TestRunArchiver', {
+                    outputDirectory: './reports/serenity-js',
+                    specDirectory: './spec',
+                }],
+            ]
+        }]
+    ],
+});
+```
+
+### Step 2: Run tests in parallel jobs
+
+Each job uploads its `test-runs/` data as a build artifact:
+
+<DynamicCodeBlock title=".github/workflows/test.yml" lang="yaml">
+{`name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
+
+    strategy:
+      matrix:
+        module: [ admin-ui, customer-ui ]
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        working-directory: modules/\${{ matrix.module }}
+        run: npx playwright test
+
+      - name: Upload test run data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-run-data-\${{ matrix.module }}
+          path: modules/\${{ matrix.module }}/reports/serenity-js/test-runs/
+          retention-days: 3
+
+  report:
+    name: Aggregate report
+    needs: [ test ]
+    if: always()
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Restore previous report (preserves trend history)
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: reports/serenity-js
+        continue-on-error: true
+
+      - name: Download test run data from all modules
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-run-data-*
+          path: test-run-data/
+
+      - name: Aggregate report
+        run: |
+          npx @serenity-js/html-reporter aggregate \\
+            --input "test-run-data/**/test-runs/*,reports/serenity-js/test-runs/*" \\
+            --output ./reports/serenity-js \\
+            --title "My Project" \\
+            --max-history 10
+
+      - name: Deploy report to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: reports/serenity-js
+          clean: true
+`}
+</DynamicCodeBlock>
+
+**What happens:**
+
+1. The `test` job matrix runs both modules in parallel. Each uploads its `test-runs/` directory as a separate artifact.
+2. The `report` job downloads all artifacts, restores the previous `gh-pages` report for trend history, then runs `aggregate` to combine everything into a single report.
+3. The combined report is deployed to GitHub Pages (on `main` only).
+
+:::tip fail-fast: false
+Set `fail-fast: false` on the test matrix so all modules run to completion even if one fails.
+This ensures the aggregated report contains results from all modules, not just the ones that happened to finish first.
+:::
+
+### Adapting for other multi-job patterns
+
+The same approach works for:
+- **Sharded Playwright tests** — replace the `module` matrix with Playwright's `--shard` flag
+- **Multi-browser testing** — matrix on browser names, each producing its own test run data
+- **Monorepo CI** — each package in a workspace uploads independently
+
+The key pattern is always the same: archive data in parallel → aggregate in a final step.
+
+## Controlling report history
+
+The [`maxHistory`](/handbook/reporting/html-reporter/#configuration-options) option limits how many test runs are retained.
+Without it, the report grows indefinitely.
+
+```typescript
+['@serenity-js/html-reporter', {
+    outputDirectory: './reports/serenity-js',
+    maxHistory: 20,  // keep the last 20 runs
+}]
+```
+
+For the CLI `aggregate` command:
+
+```sh
+npx @serenity-js/html-reporter aggregate \
+  --input "..." \
+  --output ./reports/serenity-js \
+  --max-history 20
+```
+
+:::tip Choosing a maxHistory value
+A good starting value is the number of builds you'd realistically compare when investigating a regression.
+For most teams, 10–20 runs provides useful trend data without bloating the GitHub Pages deployment.
+:::
+
+## Using Serenity BDD Reporter
+
+If your team already uses [Serenity BDD](/handbook/reporting/serenity-bdd-reporter/) or prefers its multi-page report format,
+your workflow needs Java and a separate report generation step (`serenity-bdd run`) after tests complete.
+
+The official [Serenity/JS Docker image](/handbook/integration/docker/) includes OpenJDK,
+so no additional Java setup is required when running inside the container.
+
+<DynamicCodeBlock title=".github/workflows/test.yml" lang="yaml">
+{`jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests and generate report
+        run: npm test
+        # package.json scripts:
+        #   "test": "failsafe clean test:execute test:report"
+        #   "test:execute": "npx playwright test"
+        #   "test:report": "serenity-bdd run"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: serenity-report
+          path: target/site/serenity/
+`}
+</DynamicCodeBlock>
+
+The key differences from the HTML Reporter workflow:
+- `npm test` invokes `npm-failsafe` to chain test execution and report generation
+- `serenity-bdd run` requires Java (provided by the Docker image)
+- The report output goes to `target/site/serenity/` rather than `reports/serenity-js/`
+
+→ Learn more: [Serenity BDD Reporter guide](/handbook/reporting/serenity-bdd-reporter/) | [Migrating to the HTML Reporter](/handbook/reporting/html-reporter/#migrating-from-serenity-bdd-reporter)
+
+## Learn more
+
+- [HTML Reporter](/handbook/reporting/html-reporter/) — configuration, CI integration patterns, migration from Serenity BDD
+- [Serenity/JS Docker images](/handbook/integration/docker/) — pre-configured container images for CI
+- [Serenity/JS Project Templates](/getting-started/project-templates/) — pre-configured starters with GitHub Actions workflows
+- [GitHub Pages documentation](https://docs.github.com/en/pages) — enabling and configuring GitHub Pages for your repository

--- a/src/docs/handbook/integration/github-codespaces.mdx
+++ b/src/docs/handbook/integration/github-codespaces.mdx
@@ -34,7 +34,7 @@ and adds [GitHub CLI](https://github.com/devcontainers/features/tree/main/src/gi
 <DynamicCodeBlock lang="json" title=".devcontainer/devcontainer.json" >
 {`{
     "name": "My Serenity/JS Codespace",
-    "image": "ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-noble",
+    "image": "ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute",
     "features": {
       "ghcr.io/devcontainers/features/desktop-lite:1": {},
       "ghcr.io/devcontainers/features/github-cli:1": {}

--- a/src/docs/handbook/integration/gitlab-ci.mdx
+++ b/src/docs/handbook/integration/gitlab-ci.mdx
@@ -6,12 +6,13 @@ export const PlaywrightVersion = () => <SupportedIntegrationVersion name="playwr
 
 # GitLab CI
 
-Serenity/JS offers excellent support for [GitLab CI](https://docs.gitlab.com/topics/build_your_application/):
-you can run your acceptance tests in CI, generate rich Serenity BDD reports,
-and publish both living documentation and JUnit-style test results.
+Serenity/JS integrates with [GitLab CI](https://docs.gitlab.com/topics/build_your_application/) to run your acceptance tests
+and publish interactive HTML reports with trend history, flaky test detection, and error clustering.
 
-In this guide, you'll learn how to configure your GitLab CI pipeline to use the official [Serenity/JS Docker image](/handbook/integration/docker/)
-and ensure a stable environment for running your Serenity/JS test scenarios.
+In this guide, you'll learn how to configure GitLab CI pipelines that:
+- Run Serenity/JS test scenarios using the official [Serenity/JS Docker image](/handbook/integration/docker/)
+- Publish the [HTML Reporter](/handbook/reporting/html-reporter/) output to GitLab Pages
+- Preserve execution history across builds for trend analysis
 
 ## Before you start
 
@@ -22,122 +23,364 @@ If you're new to Serenity/JS, [follow the tutorial](/handbook/tutorials/your-fir
 
 ## Running Serenity/JS on GitLab CI
 
-GitLab CI executes pipelines inside [Docker containers](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html).
+GitLab CI executes pipelines inside [Docker containers](https://docs.gitlab.com/ci/docker/using_docker_images/).
 
-To ensure stability of your execution environment, use a container with:
-- The latest Long-Term Support (LTS) version of [Node.js](https://github.com/nodejs/Release)
-- A recent Java Runtime Environment (JRE)
-- Your desired web browsers and other dependencies, as per the [Serenity/JS installation guide](/handbook/installation/)
+To ensure a stable, reproducible testing environment, use the official
+[Serenity/JS Docker image](/handbook/integration/docker/) as your job image. It comes pre-configured with:
+- The latest Long-Term Support (LTS) version of Node.js
+- All Playwright browser engines, plus stable Chrome and Edge
+- OpenJDK Java Runtime Environment (for teams also using [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/))
 
-The easiest way to do that is to:
-- Use the official [Serenity/JS Docker image](/handbook/integration/docker/) directly, as it comes pre-configured with all the required dependencies
-- Create a [custom Docker container](/handbook/integration/docker/#extending-serenityjs-docker-images) based on the official Serenity/JS Docker image to suit your needs
+The easiest way to get started is to:
+- Use the official [Serenity/JS Docker image](/handbook/integration/docker/) directly
+- Create a [custom Docker container](/handbook/integration/docker/#extending-serenityjs-docker-images) based on the official image to suit your needs
 
-## Configuring GitLab CI pipelines
-
-GitLab CI pipelines are configured using a file called [`.gitlab-ci.yml`](https://docs.gitlab.com/ci/yaml/), located at the root of your repository.
-
-A typical Serenity/JS GitLab CI pipeline consists of at least two stages:
-- `test` - responsible for running your Serenity/JS test scenarios and collecting their artifacts
-- `publish` - responsible for publishing artifacts, such as the Serenity reports, to GitLab Pages or other destinations
-
-:::tip Pipeline naming conventions
-Neither GitLab CI nor Serenity/JS force you to use any particular naming convention or structure for your pipelines.
-In this guide, we use `test` and `publish` as that's a great starting point and a convention often followed by teams using Serenity/JS.
+:::tip Why use a container image?
+Running tests inside a pre-configured container eliminates environment drift between local development and CI.
+Browser versions, system dependencies, and font rendering all stay consistent — reducing flaky failures
+caused by infrastructure differences rather than product bugs.
 :::
 
-In the example below, you see the `test` stage with a job called `serenity` that:
-- Uses the official [Serenity/JS Playwright Docker image](/handbook/integration/docker/#serenityjs-playwright-image)
-- Installs the project dependencies using `npm ci`, which is the recommended way to install Node.js modules in CI environments
-- Runs the test suite using `npm test` - all [Serenity/JS Project Templates](/getting-started/project-templates/) are pre-configured to run tests and generate reports via this standard script,
-  and you can adjust it to your needs if necessary
-- Preserves any artifacts under `target`, including the Serenity BDD reports, so that they can be reused in subsequent stages of the pipeline
+## Single-module project
 
-The `publish` stage has a job called `create-pages` that:
-- Declares a dependency on the `serenity` job to access its artifacts
-- Uses the [`pages`](https://docs.gitlab.com/ci/yaml/#pages) keyword to specify the location of the report
-- Uses the [`rules`](https://docs.gitlab.com/ci/yaml/#rules) keyword to publish the reports only when the pipeline runs on the default branch. This helps to avoid overwriting the main branch report when working on feature branches
+A single-module project has one test suite that runs in a single CI job. This is the most common setup for small to medium projects.
+
+The [`HtmlReporter`](/handbook/reporting/html-reporter/) crew member handles both data collection and report generation automatically — no separate aggregation step is needed.
+
+### Basic pipeline
+
+A typical Serenity/JS GitLab CI pipeline consists of at least two stages:
+- `test` — runs your test scenarios and preserves the report output
+- `pages` — publishes the report to GitLab Pages
 
 <DynamicCodeBlock title=".gitlab-ci.yml" lang="yaml">
 {`stages:
   - test
-  - publish
+  - pages
 
   serenity:
     stage: test
-
-    # Use the official Serenity/JS Docker image
-    image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-noble
+    image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
 
     script:
-    - npm ci
-    - npm test
+      - npm ci
+      - npm test
 
-    # Preserve test artifacts, even when the job fails
     artifacts:
       when: always
       paths:
-        - target
+        - reports/serenity-js
 
-  create-pages:
-    stage: publish
-    pages:
-      publish: target/site/serenity
-
+  pages:
+    stage: pages
     dependencies:
       - serenity
-
     script:
-      - echo "Publishing Serenity reports"
-
-    # Publish reports to GitLab Pages only on the default branch
+      - mkdir -p public
+      - cp -r reports/serenity-js/* public/
+    artifacts:
+      paths:
+        - public
     rules:
       - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-
-  # other configuration
 `}
 </DynamicCodeBlock>
 
-If your team uses merge requests in your workflow, you might want to use [GitLab Parallel Deployments](https://docs.gitlab.com/user/project/pages/parallel_deployments/)
-to publish an instance of Serenity reports per merge request.
+:::tip Always preserve artifacts
+Use `artifacts: when: always` so the report is available even when tests fail —
+that's exactly when you need it most.
+:::
+
+:::tip Pipeline naming conventions
+Neither GitLab CI nor Serenity/JS force you to use any particular naming convention for your pipelines.
+In this guide, we use `test` and `pages` as that's a great starting point and a convention often followed by teams using Serenity/JS.
+:::
+
+### Preserving trend history
+
+To enable trend analysis across builds, use GitLab CI's [`cache`](https://docs.gitlab.com/ci/caching/) to persist the `test-runs/` directory. The cache writes only on the default branch, so feature branches can read historical data but don't pollute it:
+
+<DynamicCodeBlock title=".gitlab-ci.yml" lang="yaml">
+{`stages:
+  - test
+  - pages
+
+  serenity:
+    stage: test
+    image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
+
+    rules:
+      - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+        variables:
+          CACHE_POLICY: pull-push
+      - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
+        variables:
+          CACHE_POLICY: pull
+
+    cache:
+      key: serenity-report-history
+      paths:
+        - reports/serenity-js/test-runs/
+      policy: $CACHE_POLICY
+
+    script:
+      - npm ci
+      - npm test
+
+    artifacts:
+      when: always
+      paths:
+        - reports/serenity-js
+
+  pages:
+    stage: pages
+    dependencies:
+      - serenity
+    script:
+      - mkdir -p public
+      - cp -r reports/serenity-js/* public/
+    artifacts:
+      paths:
+        - public
+    rules:
+      - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+`}
+</DynamicCodeBlock>
+
+On the default branch, the cache restores previous `test-runs/` data, the HTML Reporter aggregates all runs, and the `pages` job publishes the result. Old runs are pruned based on [`maxHistory`](/handbook/reporting/html-reporter/#configuration-options).
+
+On feature branches, tests still run and the report is available as a downloadable artifact (with read-only access to main's history) — but the cache isn't updated and Pages aren't overwritten.
+
+## Multi-module project
+
+A multi-module project runs tests across multiple parallel jobs — for example, testing separate applications,
+browser variants, or sharded test suites. Each job produces its own test data, and a final job aggregates
+everything into one report.
+
+### Example: admin-ui and customer-ui
+
+Consider a monorepo with two UI modules, each with its own test suite:
+
+```
+my-project/
+├── modules/
+│   ├── admin-ui/
+│   │   ├── spec/
+│   │   └── playwright.config.ts
+│   └── customer-ui/
+│       ├── spec/
+│       └── playwright.config.ts
+└── package.json
+```
+
+### Step 1: Configure each module to archive data only
+
+In each module's `playwright.config.ts`, use `TestRunArchiver` instead of the full `HtmlReporter`:
+
+```ts title="modules/admin-ui/playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+import type { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test';
+
+export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
+    testDir: './spec',
+
+    reporter: [
+        ['line'],
+        ['@serenity-js/playwright-test', {
+            crew: [
+                ['@serenity-js/html-reporter:TestRunArchiver', {
+                    outputDirectory: './reports/serenity-js',
+                    specDirectory: './spec',
+                }],
+            ]
+        }]
+    ],
+});
+```
+
+### Step 2: Run tests in parallel and aggregate
+
+Use GitLab CI's [`parallel:matrix`](https://docs.gitlab.com/ci/yaml/#parallelmatrix) to run modules in parallel,
+then aggregate in a final job:
+
+<DynamicCodeBlock title=".gitlab-ci.yml" lang="yaml">
+{`stages:
+  - test
+  - report
+  - pages
+
+  test:
+    stage: test
+    image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
+    parallel:
+      matrix:
+        - MODULE: [ admin-ui, customer-ui ]
+
+    script:
+      - npm ci
+      - cd modules/$MODULE && npx playwright test
+
+    artifacts:
+      when: always
+      paths:
+        - modules/$MODULE/reports/serenity-js/test-runs/
+
+  aggregate:
+    stage: report
+    image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
+    dependencies:
+      - test
+
+    script:
+      - npm ci
+      - |
+        npx @serenity-js/html-reporter aggregate \\
+          --input "modules/*/reports/serenity-js/test-runs/*" \\
+          --output ./reports/serenity-js \\
+          --title "My Project" \\
+          --max-history 10
+
+    artifacts:
+      when: always
+      paths:
+        - reports/serenity-js
+
+  pages:
+    stage: pages
+    dependencies:
+      - aggregate
+    script:
+      - mkdir -p public
+      - cp -r reports/serenity-js/* public/
+    artifacts:
+      paths:
+        - public
+    rules:
+      - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+`}
+</DynamicCodeBlock>
+
+**What happens:**
+
+1. The `test` job runs both modules in parallel via `parallel:matrix`. Each produces a `test-runs/` directory as an artifact.
+2. The `aggregate` job downloads all test artifacts, restores the previous GitLab Pages report for trend history, then combines everything into a single report.
+3. The `pages` job deploys the combined report to GitLab Pages (on the default branch only).
+
+:::tip Parallel deployments
+If your team uses merge requests, you can use [GitLab Parallel Deployments](https://docs.gitlab.com/user/project/pages/parallel_deployments/)
+to publish a separate report instance per merge request.
+:::
+
+## Controlling report history
+
+The [`maxHistory`](/handbook/reporting/html-reporter/#configuration-options) option limits how many test runs are retained.
+Without it, the report grows indefinitely.
+
+```typescript
+['@serenity-js/html-reporter', {
+    outputDirectory: './reports/serenity-js',
+    maxHistory: 20,  // keep the last 20 runs
+}]
+```
+
+For the CLI `aggregate` command:
+
+```sh
+npx @serenity-js/html-reporter aggregate \
+  --input "..." \
+  --output ./reports/serenity-js \
+  --max-history 20
+```
+
+:::tip Choosing a maxHistory value
+A good starting value is the number of builds you'd realistically compare when investigating a regression.
+For most teams, 10–20 runs provides useful trend data without bloating the cache or deployment.
+:::
 
 ## Generating JUnit reports
 
-GitLab CI recognises test execution reports that conform to the [JUnit XML standard](https://llg.cubic.org/docs/junit/).
-Serenity/JS integrates with all the **native reporters** offered by the supported [test runners](/handbook/test-runners/),
-including the ones producing JUnit reports, such as:
-- [Cucumber.js JUnit formatter](https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md#junit)
-- [Jasmine JUnit reporter](https://www.npmjs.com/package/jasmine-reporters)
-- [Mocha JUnit reporter](https://www.npmjs.com/package/mocha-junit-reporter)
+GitLab CI natively recognises test reports that conform to the [JUnit XML standard](https://llg.cubic.org/docs/junit/)
+and [surfaces test results in Merge Requests](https://docs.gitlab.com/ci/testing/unit_test_reports/).
+
+Serenity/JS integrates with the **native reporters** offered by all supported [test runners](/handbook/test-runners/),
+including those producing JUnit reports:
 - [Playwright Test JUnit reporter](https://playwright.dev/docs/test-reporters#junit-reporter)
-- [WebdriverIO](https://webdriver.io/docs/junit-reporter/)
+- [Cucumber.js JUnit formatter](https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md#junit)
+- [Mocha JUnit reporter](https://www.npmjs.com/package/mocha-junit-reporter)
+- [Jasmine JUnit reporter](https://www.npmjs.com/package/jasmine-reporters)
+- [WebdriverIO JUnit reporter](https://webdriver.io/docs/junit-reporter/)
 
-To make GitLab CI recognise a JUnit-standard report produced by your Serenity/JS test suite and [surface test results in your Merge Requests](https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html), you should:
-- Use a native JUnit reporter appropriate for your test runner
-- Configure [`artifacts:reports:junit`](https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html)  to tell GitLab where to find the report.
-
-For example, if you have configured your JUnit reporter to produce a report at `target/junit-results.xml`, you can configure your GitLab CI job as follows:
+To make GitLab surface test results, configure [`artifacts:reports:junit`](https://docs.gitlab.com/ci/testing/unit_test_reports/)
+to point to the JUnit XML output:
 
 ```yaml title=".gitlab-ci.yml"
-stages:
-  - test
-
 serenity:
   stage: test
   # ...
   artifacts:
     when: always
     paths:
-      - target
+      - reports/serenity-js
     # highlight-start
     reports:
-      junit: target/junit-results.xml
+      junit: reports/junit-results.xml
     # highlight-end
-
-# other configuration
 ```
 
 :::tip Pro Tip
-Note that in the above example I use [`artifacts:when: always`](https://docs.gitlab.com/ee/ci/yaml/#artifactswhen).
-This instructs GitLab to upload and analyse the test report even when the test run fails, which is exactly when you need your test reports the most 😊
+Use `artifacts: when: always` so GitLab uploads and analyses the JUnit report even when tests fail —
+which is exactly when you need it most 😊
 :::
+
+## Using Serenity BDD Reporter
+
+If your team already uses [Serenity BDD](/handbook/reporting/serenity-bdd-reporter/) or prefers its multi-page report format,
+your pipeline needs a separate `serenity-bdd run` step after tests complete to generate the HTML report.
+
+The official [Serenity/JS Docker image](/handbook/integration/docker/) includes OpenJDK,
+so no additional Java setup is required.
+
+<DynamicCodeBlock title=".gitlab-ci.yml" lang="yaml">
+{`stages:
+  - test
+  - pages
+
+  serenity:
+    stage: test
+    image: ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute
+
+    script:
+      - npm ci
+      - npm test
+      # package.json: "test": "failsafe clean test:execute test:report"
+      # where test:report runs: serenity-bdd run
+
+    artifacts:
+      when: always
+      paths:
+        - target/site/serenity
+
+  pages:
+    stage: pages
+    dependencies:
+      - serenity
+    script:
+      - mkdir -p public
+      - cp -r target/site/serenity/* public/
+    artifacts:
+      paths:
+        - public
+    rules:
+      - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+`}
+</DynamicCodeBlock>
+
+→ Learn more: [Serenity BDD Reporter guide](/handbook/reporting/serenity-bdd-reporter/) | [Migrating to the HTML Reporter](/handbook/reporting/html-reporter/#migrating-from-serenity-bdd-reporter)
+
+## Learn more
+
+- [HTML Reporter](/handbook/reporting/html-reporter/) — configuration, CI integration patterns, migration from Serenity BDD
+- [Serenity/JS Docker images](/handbook/integration/docker/) — pre-configured container images for CI
+- [Serenity/JS Project Templates](/getting-started/project-templates/) — pre-configured starters with CI workflows
+- [GitLab CI/CD documentation](https://docs.gitlab.com/ci/) — pipeline syntax and configuration reference
+- [GitLab Pages documentation](https://docs.gitlab.com/user/project/pages/) — publishing static sites from your repository

--- a/src/docs/handbook/integration/jenkins-ci.mdx
+++ b/src/docs/handbook/integration/jenkins-ci.mdx
@@ -1,9 +1,425 @@
+---
+title: Jenkins CI
+---
+
+export const PlaywrightVersion = () => <SupportedIntegrationVersion name="playwright-core" format="exact" />;
+
 # Jenkins CI
 
-Serenity/JS integrates with [industry-standard test runners](/handbook/test-runners/), so that your test scenarios can be executed
-using your regular build tools, <abbr title="Continuous Integration and Delivery">CI/CD</abbr> pipelines, and <abbr title="Integrated Development Environments">IDEs</abbr>.
+Serenity/JS integrates with [Jenkins](https://www.jenkins.io/) to run your acceptance tests
+and publish interactive HTML reports with trend history, flaky test detection, and error clustering.
 
-In this article, I'll show you how to configure [Jenkins CI](https://www.jenkins.io/),
-to run automated acceptance tests built using Serenity/JS, and publish test execution reports and living documentation.
+In this guide, you'll learn how to configure Jenkins pipelines that:
+- Run Serenity/JS test scenarios using the official [Serenity/JS Docker image](/handbook/integration/docker/)
+- Publish the [HTML Reporter](/handbook/reporting/html-reporter/) output using the [HTML Publisher plugin](https://plugins.jenkins.io/htmlpublisher/)
+- Preserve execution history across builds for trend analysis
 
-<ArticleComingSoon />
+## Before you start
+
+Set up a working Serenity/JS test suite using one of the official [Serenity/JS Project Templates](/getting-started/project-templates/),
+or add Serenity/JS to your existing project by following the [Serenity/JS installation guide](/handbook/installation/).
+
+If you're new to Serenity/JS, [follow the tutorial](/handbook/tutorials/your-first-web-scenario) to learn more about the framework.
+
+## Running Serenity/JS on Jenkins
+
+Jenkins pipelines can run inside [Docker containers](https://www.jenkins.io/doc/book/pipeline/docker/) using the `agent { docker }` directive.
+
+To ensure a stable, reproducible testing environment, use the official
+[Serenity/JS Docker image](/handbook/integration/docker/) as your build agent. It comes pre-configured with:
+- The latest Long-Term Support (LTS) version of Node.js
+- All Playwright browser engines, plus stable Chrome and Edge
+- OpenJDK Java Runtime Environment (for teams also using [Serenity BDD Reporter](/handbook/reporting/serenity-bdd-reporter/))
+
+:::tip Why use a Docker agent?
+Running tests inside a container eliminates environment drift between developer machines, Jenkins agents, and other CI environments.
+Browser versions, system dependencies, and font rendering all stay consistent — reducing flaky failures
+caused by infrastructure differences rather than product bugs.
+:::
+
+## Prerequisites
+
+Ensure the following Jenkins plugins are installed:
+- [Docker Pipeline](https://plugins.jenkins.io/docker-workflow/) — enables Docker-based build agents
+- [HTML Publisher](https://plugins.jenkins.io/htmlpublisher/) — publishes HTML reports in the Jenkins UI
+
+## Single-module project
+
+A single-module project has one test suite that runs in a single pipeline. This is the most common setup for small to medium projects.
+
+The [`HtmlReporter`](/handbook/reporting/html-reporter/) crew member handles both data collection and report generation automatically — no separate aggregation step is needed.
+
+### Basic pipeline
+
+<DynamicCodeBlock title="Jenkinsfile" lang="groovy">
+{`pipeline {
+    agent {
+        docker {
+            image 'ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute'
+            args '--ipc=host'
+        }
+    }
+
+    stages {
+        stage('Install') {
+            steps {
+                sh 'npm ci'
+            }
+        }
+
+        stage('Test') {
+            steps {
+                sh 'npm test'
+            }
+        }
+    }
+
+    post {
+        always {
+            publishHTML(target: [
+                reportName: 'Serenity Report',
+                reportDir: 'reports/serenity-js',
+                reportFiles: 'index.html',
+                keepAll: true,
+                alwaysLinkToLastBuild: true,
+                allowMissing: true,
+            ])
+        }
+    }
+}
+`}
+</DynamicCodeBlock>
+
+:::tip --ipc=host
+The `--ipc=host` argument prevents Chromium from running out of shared memory in containerised environments.
+Without it, browser tests may crash with "out of memory" errors on agents with limited `/dev/shm`.
+:::
+
+### Preserving trend history
+
+To enable trend analysis across builds, restore the previous report's `test-runs/` directory before running tests.
+The simplest approach is to archive the report and use the [Copy Artifact plugin](https://plugins.jenkins.io/copyartifact/) to restore it from the last successful build:
+
+<DynamicCodeBlock title="Jenkinsfile" lang="groovy">
+{`pipeline {
+    agent {
+        docker {
+            image 'ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute'
+            args '--ipc=host'
+        }
+    }
+
+    stages {
+        stage('Restore history') {
+            steps {
+                // Copy test-runs from the last successful build's archived report
+                copyArtifacts(
+                    projectName: env.JOB_NAME,
+                    selector: lastCompleted(),
+                    filter: 'reports/serenity-js/test-runs/**',
+                    optional: true,
+                    fingerprintArtifacts: false,
+                )
+            }
+        }
+
+        stage('Install') {
+            steps {
+                sh 'npm ci'
+            }
+        }
+
+        stage('Test') {
+            steps {
+                sh 'npm test'
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts(
+                artifacts: 'reports/serenity-js/**',
+                allowEmptyArchive: true,
+            )
+            publishHTML(target: [
+                reportName: 'Serenity Report',
+                reportDir: 'reports/serenity-js',
+                reportFiles: 'index.html',
+                keepAll: true,
+                alwaysLinkToLastBuild: true,
+                allowMissing: true,
+            ])
+        }
+    }
+}
+`}
+</DynamicCodeBlock>
+
+**How trend history works:**
+
+1. The "Restore history" stage copies `test-runs/` from the last successful build into the workspace.
+2. When tests run, the `HtmlReporter` writes new data to `reports/serenity-js/test-runs/<runId>/` and aggregates all available runs into the final report.
+3. After tests complete, `archiveArtifacts` preserves the full report directory for the next build to restore.
+
+Use the [`maxHistory`](/handbook/reporting/html-reporter/#configuration-options) option to control how many runs are retained.
+
+:::note Copy Artifact plugin
+The "Restore history" stage requires the [Copy Artifact plugin](https://plugins.jenkins.io/copyartifact/).
+:::
+
+## Multi-module project
+
+A multi-module project runs tests across multiple parallel stages — for example, testing separate applications,
+browser variants, or sharded test suites. Each stage produces its own test data, and a final stage aggregates
+everything into one report.
+
+### Example: admin-ui and customer-ui
+
+Consider a monorepo with two UI modules, each with its own test suite:
+
+```
+my-project/
+├── modules/
+│   ├── admin-ui/
+│   │   ├── spec/
+│   │   └── playwright.config.ts
+│   └── customer-ui/
+│       ├── spec/
+│       └── playwright.config.ts
+└── package.json
+```
+
+### Step 1: Configure each module to archive data only
+
+In each module's `playwright.config.ts`, use `TestRunArchiver` instead of the full `HtmlReporter`:
+
+```ts title="modules/admin-ui/playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+import type { SerenityFixtures, SerenityWorkerFixtures } from '@serenity-js/playwright-test';
+
+export default defineConfig<SerenityFixtures, SerenityWorkerFixtures>({
+    testDir: './spec',
+
+    reporter: [
+        ['line'],
+        ['@serenity-js/playwright-test', {
+            crew: [
+                ['@serenity-js/html-reporter:TestRunArchiver', {
+                    outputDirectory: './reports/serenity-js',
+                    specDirectory: './spec',
+                }],
+            ]
+        }]
+    ],
+});
+```
+
+### Step 2: Run tests in parallel and aggregate
+
+Use Jenkins [parallel stages](https://www.jenkins.io/doc/book/pipeline/syntax/#parallel) to run modules concurrently,
+then aggregate in a final stage:
+
+<DynamicCodeBlock title="Jenkinsfile" lang="groovy">
+{`pipeline {
+    agent {
+        docker {
+            image 'ghcr.io/serenity-js/playwright:v`}<PlaywrightVersion />{`-resolute'
+            args '--ipc=host'
+        }
+    }
+
+    stages {
+        stage('Install') {
+            steps {
+                sh 'npm ci'
+            }
+        }
+
+        stage('Restore history') {
+            steps {
+                copyArtifacts(
+                    projectName: env.JOB_NAME,
+                    selector: lastCompleted(),
+                    filter: 'reports/serenity-js/test-runs/**',
+                    optional: true,
+                    fingerprintArtifacts: false,
+                )
+            }
+        }
+
+        stage('Test') {
+            parallel {
+                stage('admin-ui') {
+                    steps {
+                        dir('modules/admin-ui') {
+                            sh 'npx playwright test'
+                        }
+                    }
+                }
+                stage('customer-ui') {
+                    steps {
+                        dir('modules/customer-ui') {
+                            sh 'npx playwright test'
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Aggregate report') {
+            steps {
+                sh """
+                    npx @serenity-js/html-reporter aggregate \\
+                        --input "modules/*/reports/serenity-js/test-runs/*,reports/serenity-js/test-runs/*" \\
+                        --output ./reports/serenity-js \\
+                        --title "My Project" \\
+                        --max-history 10
+                """
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts(
+                artifacts: 'reports/serenity-js/**',
+                allowEmptyArchive: true,
+            )
+            publishHTML(target: [
+                reportName: 'Serenity Report',
+                reportDir: 'reports/serenity-js',
+                reportFiles: 'index.html',
+                keepAll: true,
+                alwaysLinkToLastBuild: true,
+                allowMissing: true,
+            ])
+        }
+    }
+}
+`}
+</DynamicCodeBlock>
+
+**What happens:**
+
+1. Both modules run in parallel. Each produces a `test-runs/` directory in its own `reports/serenity-js/`.
+2. The "Aggregate report" stage combines all module data plus the restored historical data into a single report.
+3. The `post` block archives the combined report and publishes it via the HTML Publisher plugin.
+
+## Controlling report history
+
+The [`maxHistory`](/handbook/reporting/html-reporter/#configuration-options) option limits how many test runs are retained.
+Without it, the report grows indefinitely.
+
+```typescript
+['@serenity-js/html-reporter', {
+    outputDirectory: './reports/serenity-js',
+    maxHistory: 20,  // keep the last 20 runs
+}]
+```
+
+For the CLI `aggregate` command:
+
+```sh
+npx @serenity-js/html-reporter aggregate \
+  --input "..." \
+  --output ./reports/serenity-js \
+  --max-history 20
+```
+
+:::tip Choosing a maxHistory value
+A good starting value is the number of builds you'd realistically compare when investigating a regression.
+For most teams, 10–20 runs provides useful trend data without bloating artifact storage.
+:::
+
+## Generating JUnit reports
+
+Jenkins natively recognises [JUnit XML reports](https://plugins.jenkins.io/junit/) and surfaces test results
+in the build dashboard, including trend graphs and failure details.
+
+Serenity/JS integrates with the **native reporters** offered by all supported [test runners](/handbook/test-runners/),
+including those producing JUnit reports:
+- [Playwright Test JUnit reporter](https://playwright.dev/docs/test-reporters#junit-reporter)
+- [Cucumber.js JUnit formatter](https://github.com/cucumber/cucumber-js/blob/main/docs/formatters.md#junit)
+- [Mocha JUnit reporter](https://www.npmjs.com/package/mocha-junit-reporter)
+- [Jasmine JUnit reporter](https://www.npmjs.com/package/jasmine-reporters)
+- [WebdriverIO JUnit reporter](https://webdriver.io/docs/junit-reporter/)
+
+To surface test results in Jenkins, add a `junit` post step:
+
+```groovy title="Jenkinsfile"
+post {
+    always {
+        // highlight-start
+        junit(
+            testResults: 'reports/junit-results.xml',
+            allowEmptyResults: true,
+        )
+        // highlight-end
+        publishHTML(target: [
+            reportName: 'Serenity Report',
+            reportDir: 'reports/serenity-js',
+            reportFiles: 'index.html',
+            keepAll: true,
+            alwaysLinkToLastBuild: true,
+            allowMissing: true,
+        ])
+    }
+}
+```
+
+:::tip Content Security Policy
+By default, Jenkins blocks inline JavaScript in published HTML reports via its [Content Security Policy](https://www.jenkins.io/doc/book/security/configuring-content-security-policy/).
+The Serenity/JS HTML Report requires JavaScript to function. To allow it, configure the CSP header in
+**Manage Jenkins → Script Console**:
+
+```groovy
+System.setProperty("hudson.model.DirectoryBrowserSupport.CSP", "")
+```
+
+For a persistent fix, add this to your Jenkins startup arguments or use the
+[Permissive Script Security plugin](https://plugins.jenkins.io/permissive-script-security/).
+:::
+
+## Using Serenity BDD Reporter
+
+If you're using [`@serenity-js/serenity-bdd`](/handbook/reporting/serenity-bdd-reporter/) instead of the HTML Reporter,
+your pipeline needs a `serenity-bdd run` step after tests complete to generate the HTML report.
+
+The official [Serenity/JS Docker image](/handbook/integration/docker/) includes OpenJDK,
+so no additional Java setup is required.
+
+```groovy title="Jenkinsfile"
+stage('Test') {
+    steps {
+        sh 'npm test'
+        // package.json: "test": "failsafe clean test:execute test:report"
+        // where test:report runs: serenity-bdd run
+    }
+}
+
+post {
+    always {
+        publishHTML(target: [
+            reportName: 'Serenity BDD Report',
+            reportDir: 'target/site/serenity',
+            reportFiles: 'index.html',
+            keepAll: true,
+            alwaysLinkToLastBuild: true,
+            allowMissing: true,
+        ])
+    }
+}
+```
+
+See the [Serenity BDD Reporter documentation](/handbook/reporting/serenity-bdd-reporter/) for full configuration,
+or consider [migrating to the HTML Reporter](/handbook/reporting/html-reporter/#migrating-from-serenity-bdd-reporter)
+for a simpler CI setup with built-in trend analysis.
+
+## Learn more
+
+- [HTML Reporter](/handbook/reporting/html-reporter/) — configuration, CI integration patterns, migration from Serenity BDD
+- [Serenity/JS Docker images](/handbook/integration/docker/) — pre-configured container images for CI
+- [Serenity/JS Project Templates](/getting-started/project-templates/) — pre-configured starters with CI workflows
+- [Jenkins Pipeline documentation](https://www.jenkins.io/doc/book/pipeline/) — pipeline syntax and configuration reference
+- [Jenkins Docker Pipeline plugin](https://plugins.jenkins.io/docker-workflow/) — running builds inside Docker containers


### PR DESCRIPTION
- GitHub Actions: single-module and multi-module workflows with Docker image, GitHub Pages deployment, trend history preservation
- GitLab CI: HTML Reporter as primary, multi-module with parallel:matrix, JUnit reporting, Serenity BDD as alternative
- Jenkins CI: Docker agent, HTML Publisher plugin, CSP configuration, parallel stages, Copy Artifact for trend history
- GitHub Codespaces: update Docker image suffix to -resolute

All guides recommend the Serenity/JS Docker image and show both single-job and multi-job (aggregation) patterns.